### PR TITLE
Add "repository" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0-alpha.1",
   "description": "",
   "main": "index.js",
+  "repository": "facebook/fbjs",
   "scripts": {
     "test": "NODE_ENV=test jest",
     "build": "gulp build",


### PR DESCRIPTION
Silences this warning when running `npm install`:

```
npm WARN package.json fbjs@0.1.0-alpha.1 No repository field.
```