### PR TITLE
Replace Promise => promise module mapping with Promise module

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,8 +26,9 @@ var babelOpts = {
     'es7.trailingFunctionCommas'
   ],
   plugins: [babelPluginDEV, babelPluginRequires],
+  // NOTE: we don't need this here but it's available as an example for consumers
   _moduleMap: {
-    'Promise': 'promise'
+    // 'everySet': 'lodash'
   }
 };
 

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -10,10 +10,7 @@ var babelOpts = {
   optional: [
     'es7.trailingFunctionCommas'
   ],
-  plugins: [babelPluginRequires],
-  _moduleMap: {
-    'Promise': 'promise'
-  }
+  plugins: [babelPluginRequires]
 };
 
 module.exports = {

--- a/src/polyfill/Promise.js
+++ b/src/polyfill/Promise.js
@@ -1,0 +1,7 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * @providesModule Promise
+ */
+
+module.exports = require('promise');


### PR DESCRIPTION
Instead of using `_moduleMap`, this adds a `Promise` module that simply exports `promise`.

Ideally, we would just use `_moduleMap` and avoid the (tiny) overhead of having a `Promise` module. However, this is insufficient for Flow which processes the files pre-transpilation. Without this, `flow check` would complain that it cannot find a module named `Promise`.