### PR TITLE
Add `fetchWithRetries` and `fetch` polyfill

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,7 @@ var babelOpts = {
     'spec.functionName'
   ],
   optional: [
+    'es7.objectRestSpread',
     'es7.trailingFunctionCommas'
   ],
   plugins: [babelPluginDEV, babelPluginRequires],

--- a/package.json
+++ b/package.json
@@ -48,10 +48,20 @@
       "<rootDir>/src"
     ],
     "unmockedModulePathPatterns": [
-      ""
+      "<rootDir>/node_modules/",
+      "<rootDir>/src/__forks__/",
+      "<rootDir>/src/core/",
+      "<rootDir>/src/functional/",
+      "<rootDir>/src/key-mirror/",
+      "<rootDir>/src/performance/",
+      "<rootDir>/src/polyfill/",
+      "<rootDir>/src/request/",
+      "<rootDir>/src/stubs/",
+      "<rootDir>/src/utils/"
     ]
   },
   "dependencies": {
-    "promise": "^7.0.3"
+    "promise": "^7.0.3",
+    "whatwg-fetch": "^0.9.0"
   }
 }

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -8,6 +8,7 @@ var assign = require('object-assign');
 var babelOpts = {
   nonStandard: true,
   optional: [
+    'es7.objectRestSpread',
     'es7.trailingFunctionCommas'
   ],
   plugins: [babelPluginRequires]

--- a/src/fetch/__mocks__/fetch.js
+++ b/src/fetch/__mocks__/fetch.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var Deferred = require.requireActual('Deferred');
+
+function fetch(uri: string, options: Object): Promise {
+  var deferred = new Deferred();
+  fetch.mock.calls.push([uri, options]);
+  fetch.mock.deferreds.push(deferred);
+  return deferred.getPromise();
+}
+
+fetch.mock = {
+  calls: [],
+  deferreds: [],
+};
+
+module.exports = fetch;

--- a/src/fetch/__mocks__/fetchWithRetries.js
+++ b/src/fetch/__mocks__/fetchWithRetries.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = jest.genMockFunction().mockImplementation(
+  require.requireActual('fetchWithRetries')
+);

--- a/src/fetch/__tests__/fetchMock-test.js
+++ b/src/fetch/__tests__/fetchMock-test.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+describe('fetchMock', () => {
+  var Deferred;
+
+  var fetch;
+
+  beforeEach(() => {
+    Deferred = require('Deferred');
+    fetch = require('fetch');
+  });
+
+  it('has a corresponding `Deferred` for each call to `fetch`', () => {
+    expect(fetch.mock.calls.length).toBe(0);
+    expect(fetch.mock.deferreds.length).toBe(0);
+    var promise = fetch('//localhost', {});
+    expect(fetch.mock.calls.length).toBe(1);
+    expect(fetch.mock.deferreds.length).toBe(1);
+    var deferred = fetch.mock.deferreds[0];
+    expect(deferred instanceof Deferred).toBe(true);
+    var mockCallback = jest.genMockFunction();
+    var mockResult = {};
+    expect(mockCallback).not.toBeCalled();
+    promise.then(mockCallback);
+    deferred.resolve(mockResult);
+    jest.runAllTimers();
+    expect(mockCallback).toBeCalledWith(mockResult);
+  });
+
+});

--- a/src/fetch/__tests__/fetchWithRetries-test.js
+++ b/src/fetch/__tests__/fetchWithRetries-test.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+jest.mock('warning');
+
+describe('fetchWithRetries', () => {
+  var fetch;
+  var fetchWithRetries;
+  var handleNext;
+
+  function mockResponse(status) {
+    return {status};
+  }
+
+  beforeEach(() => {
+    jest.resetModuleRegistry();
+
+    fetch = require('fetch');
+    fetchWithRetries = require('fetchWithRetries');
+    handleNext = jest.genMockFunction();
+  });
+
+  it('sends a request to the given URI', () => {
+    expect(fetch).not.toBeCalled();
+    var init = {
+      body: '',
+      method: 'GET',
+    };
+    fetchWithRetries('https://localhost', init);
+    expect(fetch).toBeCalledWith('https://localhost', init);
+  });
+
+  it('resolves the promise when the `fetch` was successful', () => {
+    var response = mockResponse(200);
+    fetchWithRetries('https://localhost', {}).then(handleNext);
+    fetch.mock.deferreds[0].resolve(response);
+    expect(handleNext).not.toBeCalled();
+    jest.runAllTimers();
+    expect(handleNext).toBeCalledWith(response);
+  });
+
+  it(
+    'rejects the promise if an error occurred during fetch and no more ' +
+    'retries should be attempted',
+    () => {
+      // Disable retries for this test
+      var error = new Error();
+      var retryDelays = [];
+      fetchWithRetries('https://localhost', {retryDelays}).catch(handleNext);
+      fetch.mock.deferreds[0].reject(error);
+      expect(handleNext).not.toBeCalled();
+      jest.runAllTimers();
+      expect(handleNext).toBeCalledWith(error);
+    }
+  );
+
+  it('retries the request if the previous attempt failed', () => {
+    var failedResponse = mockResponse(500);
+    fetchWithRetries('https://localhost', {}).then(handleNext);
+    expect(fetch.mock.calls.length).toBe(1);
+    fetch.mock.deferreds[0].resolve(failedResponse);
+    for (var ii = 0; ii < 100; ii++) {
+      if (fetch.mock.calls.length < 2) {
+        jest.runOnlyPendingTimers();
+      } else {
+        break;
+      }
+    }
+    // Resolved with `failedResponse`, next run is scheduled
+    expect(fetch.mock.calls.length).toBe(2);
+    var successfulResponse = mockResponse(200);
+    fetch.mock.deferreds[1].resolve(successfulResponse);
+    expect(handleNext).not.toBeCalled();
+    jest.runAllTimers();
+    expect(handleNext).toBeCalledWith(successfulResponse);
+  });
+
+  it('retries the request if the previous attempt timed-out', () => {
+    var retries;
+    var retryDelays = [1000, 3000];
+    var init = {retryDelays};
+    fetchWithRetries('https://localhost', init).catch(handleNext);
+    expect(fetch.mock.calls.length).toBe(1);
+    for (
+      retries = 0;
+      retries < retryDelays.length;
+      retries++
+    ) {
+      // Timeout request
+      jest.runAllTimers();
+      // Delay before next try
+      jest.runAllTimers();
+    }
+    expect(fetch.mock.calls.length).toBe(retries + 1);
+    // Timeout last request
+    jest.runAllTimers();
+    expect(handleNext.mock.calls[0][0]).toEqual(new Error(
+      'fetchWithRetries',
+      'Failed to get response from server, tried ' + retries + ' times',
+    ));
+  });
+});

--- a/src/fetch/fetch.js
+++ b/src/fetch/fetch.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule fetch
+ */
+
+'use strict';
+
+module.exports = require('whatwg-fetch');

--- a/src/fetch/fetchWithRetries.js
+++ b/src/fetch/fetchWithRetries.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule fetchWithRetries
+ * @typechecks
+ * @flow
+ */
+
+'use strict';
+
+var ExecutionEnvironment = require('ExecutionEnvironment');
+var Promise = require('Promise');
+
+var sprintf = require('sprintf');
+var fetch = require('fetch');
+var warning = require('warning');
+
+type InitWitRetries = {
+  body?: mixed;
+  cache?: ?string;
+  credentials?: ?string;
+  fetchTimeout?: number;
+  headers?: mixed;
+  method?: ?string;
+  mode?: ?string;
+  retryDelays?: Array<number>;
+};
+
+var DEFAULT_FETCH_TIMEOUT = 15000;
+var DEFAULT_RETRY_DELAYS = [1000, 3000];
+
+/**
+ * Posts a request to the server with the given data as the payload.
+ * Automatic reties are done based on the value of `retryDelays` in
+ * `RelayNetworkConfig`.
+ */
+function fetchWithRetries(
+  uri: string,
+  initWithRetries: InitWitRetries
+): Promise {
+  var {fetchTimeout, retryDelays, ...init} = initWithRetries;
+  var nonNullFetchTimeout = fetchTimeout || DEFAULT_FETCH_TIMEOUT;
+  var nonNullRetryDelays = retryDelays || DEFAULT_RETRY_DELAYS;
+
+  // How many attempts were made to send the data to the server
+  var requestsAttempted = 0;
+  var requestStartTime = 0;
+  return new Promise((resolve, reject) => {
+    /**
+     * Sends a request to the server that will timeout after
+     * `RelayNetworkConfig.fetchTimeout`.
+     * If the request fails or times out a new request might be scheduled
+     */
+    function sendTimedRequest(): void {
+      requestsAttempted++;
+      requestStartTime = Date.now();
+      var isRequestAlive = true;
+      var request = fetch(uri, init);
+      var requestTimeout = setTimeout(() => {
+        isRequestAlive = false;
+        if (shouldRetry(requestsAttempted)) {
+          warning(false, 'fetchWithRetries: HTTP timeout, retrying.');
+          retryRequest();
+        } else {
+          reject(new Error(sprintf(
+            'fetchWithRetries(): Failed to get response from server, ' +
+            'tried %s times.',
+            requestsAttempted
+          )));
+        }
+      }, nonNullFetchTimeout);
+
+      request.then(response => {
+        clearTimeout(requestTimeout);
+        if (isRequestAlive) {
+          // We got a response, we can clear the timeout
+          if (response.status >= 200 && response.status < 300) {
+            // Got a response code that indicates success, resolve the promise.
+            resolve(response);
+          } else if (shouldRetry(requestsAttempted)) {
+            // Fetch was not successful, retrying
+            // TODO(#7595849): Only retry on transient HTTP errors.
+            warning(false, 'fetchWithRetries: HTTP error, retrying.'),
+            retryRequest();
+          } else {
+            // Request was not successful, giving up.
+            reject(response);
+          }
+        }
+      }).catch(error => {
+        clearTimeout(requestTimeout);
+        if (shouldRetry(requestsAttempted)) {
+          retryRequest();
+        } else {
+          reject(error);
+        }
+      });
+    }
+
+    /**
+     * Schedules another run of sendTimedRequest based on how much time has
+     * passed between the time the last request was sent and now
+     */
+    function retryRequest(): void {
+      var retryDelay = nonNullRetryDelays[requestsAttempted - 1];
+      var retryStartTime = requestStartTime + retryDelay;
+      // Schedule retry for a configured duration after last request started.
+      setTimeout(sendTimedRequest, retryStartTime - Date.now());
+    }
+
+    /**
+     * Checks if another attempt should be doen to send a request to the server
+     */
+    function shouldRetry(attempt: number): boolean {
+      return (
+        ExecutionEnvironment.canUseDOM &&
+        attempt <= nonNullRetryDelays.length
+      );
+    }
+
+    sendTimedRequest();
+  });
+}
+
+module.exports = fetchWithRetries;


### PR DESCRIPTION
Adds the `fetchWithRetries` module. This requires a `fetch` polyfill, so I've also added `whatwg-fetch` as a package dependency.

I also had to add the `es7.objectRestSpread` Babel transform because `fetchWithRetries` uses a destructured assignment with object rest properties.