### PR TITLE
Match \r or \r\n linebreaks when scanning for @providesModule

### DIFF
--- a/scripts/gulp/module-map.js
+++ b/scripts/gulp/module-map.js
@@ -14,7 +14,7 @@ var through = require('through2');
 var fs = require('fs');
 var path = require('path');
 
-var PM_REGEXP = /\n \* \@providesModule (\S+)\n/;
+var PM_REGEXP = /\r?\n \* \@providesModule (\S+)\r?\n/;
 
 var PLUGIN_NAME = 'module-map';
 


### PR DESCRIPTION
My module-map.json contained only an empty object, post-build, on my machine. Making the `@providesModule` regex less restrictive with respect to line breaks fixed it.