### PR TITLE
Map es6-map, promise, and whatwg-fetch to the corresponding npm modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,9 +27,10 @@ var babelOpts = {
     'es7.trailingFunctionCommas'
   ],
   plugins: [babelPluginDEV, babelPluginRequires],
-  // NOTE: we don't need this here but it's available as an example for consumers
   _moduleMap: {
-    // 'everySet': 'lodash'
+    'es6-map': 'es6-map',
+    'promise': 'promise',
+    'whatwg-fetch': 'whatwg-fetch'
   }
 };
 


### PR DESCRIPTION
Prevents these requires from being rewritten as `require('./es6-map')`, et cetera.