### PR TITLE
Sync a couple changes from React

### DIFF
--- a/src/__forks__/warning.js
+++ b/src/__forks__/warning.js
@@ -31,13 +31,6 @@ if (__DEV__) {
       );
     }
 
-    if (format.length < 10 || /^[s\W]*$/.test(format)) {
-      throw new Error(
-        'The warning format should be able to uniquely identify this ' +
-        'warning. Please, use a more descriptive format than: ' + format
-      );
-    }
-
     if (format.indexOf('Failed Composite propType: ') === 0) {
       return; // Ignore CompositeComponent proptype check.
     }

--- a/src/stubs/EventListener.js
+++ b/src/stubs/EventListener.js
@@ -59,7 +59,14 @@ var EventListener = {
    * @return {object} Object with a `remove` method.
    */
   capture: function(target, eventType, callback) {
-    if (!target.addEventListener) {
+    if (target.addEventListener) {
+      target.addEventListener(eventType, callback, true);
+      return {
+        remove: function () {
+          target.removeEventListener(eventType, callback, true);
+        }
+      };
+    } else {
       if (__DEV__) {
         console.error(
           'Attempted to listen to events during the capture phase on a ' +
@@ -69,13 +76,6 @@ var EventListener = {
       }
       return {
         remove: emptyFunction
-      };
-    } else {
-      target.addEventListener(eventType, callback, true);
-      return {
-        remove: function() {
-          target.removeEventListener(eventType, callback, true);
-        }
       };
     }
   },


### PR DESCRIPTION
- EventListener is just some reorganized logic.
- warning has the runtime argument check removed. We have a lint rule in
  React for that (which I'll bring over here at some point). We have the
  same rule internally.