### PR TITLE
Build manual mocks into lib/__mocks__

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,7 +43,7 @@ var moduleMapOpts = {
 };
 
 gulp.task('clean', function(cb) {
-  del([paths.lib.dest, paths.flowInclude], cb);
+  del([paths.lib.dest, paths.mocks.dest, paths.flowInclude], cb);
 });
 
 gulp.task('lib', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ var gulp = require('gulp');
 var babel = require('gulp-babel');
 var flatten = require('gulp-flatten');
 var del = require('del');
+var mergeStream = require('merge-stream');
 var runSequence = require('run-sequence');
 
 var babelPluginDEV = require('./scripts/babel/dev-expression');
@@ -10,12 +11,23 @@ var babelDefaultOptions = require('./scripts/babel/default-options');
 var gulpModuleMap = require('./scripts/gulp/module-map.js');
 
 var paths = {
-  src: [
-    'src/**/*.js',
-    '!src/**/__tests__/**/*.js',
-    '!src/**/__mocks__/**/*.js'
-  ],
-  lib: 'lib',
+  lib: {
+    src: [
+      'src/**/*.js',
+      '!src/**/__tests__/**/*.js',
+      '!src/**/__mocks__/**/*.js'
+    ],
+    dest: 'lib'
+  },
+  mocks: {
+    src: [
+      'src/**/__mocks__/**/*.js'
+    ],
+    dest: 'lib/__mocks__',
+    babelOpts: {
+      _modulePrefix: '../'
+    }
+  },
   flowInclude: 'flow/include'
 };
 
@@ -31,24 +43,32 @@ var moduleMapOpts = {
 };
 
 gulp.task('clean', function(cb) {
-  del([paths.lib, paths.flowInclude], cb);
+  del([paths.lib.dest, paths.flowInclude], cb);
 });
 
 gulp.task('lib', function() {
-  return gulp
-    .src(paths.src)
+  var libTask = gulp
+    .src(paths.lib.src)
     .pipe(gulpModuleMap(moduleMapOpts))
     .pipe(babel(babelOpts))
     .pipe(flatten())
-    .pipe(gulp.dest(paths.lib));
+    .pipe(gulp.dest(paths.lib.dest));
+
+  var mockTask = gulp
+    .src(paths.mocks.src)
+    .pipe(babel(assign({}, babelOpts, paths.mocks.babelOpts)))
+    .pipe(flatten())
+    .pipe(gulp.dest(paths.mocks.dest));
+
+  return mergeStream(libTask, mockTask);
 });
 
 gulp.task('flow', function() {
   return gulp
-    .src(paths.src)
+    .src(paths.lib.src)
     .pipe(flatten())
     .pipe(gulp.dest(paths.flowInclude));
-})
+});
 
 gulp.task('watch', function() {
   gulp.watch(paths.src, ['lib', 'flow']);

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
   "devDependencies": {
     "babel": "^5.4.7",
     "del": "^1.2.0",
-    "gulp": "^3.8.11",
+    "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
     "gulp-flatten": "^0.1.1",
     "gulp-util": "^3.0.4",
     "jest-cli": "^0.4.5",
+    "merge-stream": "^0.1.8",
     "object-assign": "^3.0.0",
     "run-sequence": "^1.1.0",
     "through2": "^2.0.0"

--- a/scripts/babel/rewrite-modules.js
+++ b/scripts/babel/rewrite-modules.js
@@ -21,7 +21,8 @@ function mapModule(context, module) {
   }
   // Jest understands the haste module system, so leave modules intact.
   if (process.env.NODE_ENV !== 'test') {
-    return './' + module;
+    var modulePrefix = context.state.opts._modulePrefix || './';
+    return modulePrefix + module;
   }
 }
 


### PR DESCRIPTION
Exports manual mocks so that composite projects can run tests using them.