### PR TITLE
Respect the empty string as a module rewrite prefix

### DIFF
--- a/scripts/babel/rewrite-modules.js
+++ b/scripts/babel/rewrite-modules.js
@@ -21,7 +21,10 @@ function mapModule(context, module) {
   }
   // Jest understands the haste module system, so leave modules intact.
   if (process.env.NODE_ENV !== 'test') {
-    var modulePrefix = context.state.opts._modulePrefix || './';
+    var modulePrefix = context.state.opts._modulePrefix;
+    if (modulePrefix == null) {
+      modulePrefix = './';
+    }
     return modulePrefix + module;
   }
 }


### PR DESCRIPTION
Fixes #31

This still allows other crappy prefixes like `false`. We could probably do a `typeof === 'string'` check instead…

cc @yungsters