### PR TITLE
Remove `../flow` from .flowconfig

### DIFF
--- a/src/.flowconfig
+++ b/src/.flowconfig
@@ -5,7 +5,7 @@
 ../node_modules/promise
 
 [libs]
-../flow
+../flow/lib
 
 [options]
 module.system=haste


### PR DESCRIPTION
The `flow/include` directory only contains output for consumers of **facebook/fbjs**. These double up on all the definitions in `src/`.

Fixing this fixes all the issues when running `flow check src`.