### PR TITLE
Enable TravisCI, typecheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - 'iojs'
+env:
+  - CMD=test
+  - CMD=typecheck
+script: npm run $CMD

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
   "scripts": {
     "build": "gulp build",
     "prepublish": "npm run build",
-    "test": "NODE_ENV=test jest"
+    "test": "NODE_ENV=test jest",
+    "typecheck": "flow check src"
   },
   "author": "",
   "license": "BSD-3-Clause",
   "devDependencies": {
     "babel": "^5.4.7",
     "del": "^1.2.0",
+    "flow-bin": "^0.14.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
     "gulp-flatten": "^0.1.1",


### PR DESCRIPTION
`flow-bin` downloads flow and sets that up so we don't have to worry about that, which is nice.

I think this will do what we want… fail for both typechecks and tests. We'll need to turn on travis though to actually see.