### PR TITLE
Split scripts into standalone package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,9 +6,9 @@ var del = require('del');
 var mergeStream = require('merge-stream');
 var runSequence = require('run-sequence');
 
-var babelPluginDEV = require('./scripts/babel/dev-expression');
-var babelDefaultOptions = require('./scripts/babel/default-options');
-var gulpModuleMap = require('./scripts/gulp/module-map.js');
+var babelPluginDEV = require('fbjs-scripts/babel/dev-expression');
+var babelDefaultOptions = require('fbjs-scripts/babel/default-options');
+var gulpModuleMap = require('fbjs-scripts/gulp/module-map.js');
 
 var paths = {
   lib: {

--- a/package.json
+++ b/package.json
@@ -15,16 +15,15 @@
   "devDependencies": {
     "babel": "^5.4.7",
     "del": "^1.2.0",
+    "fbjs-scripts": "file:scripts",
     "flow-bin": "^0.14.0",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
     "gulp-flatten": "^0.1.1",
-    "gulp-util": "^3.0.4",
     "jest-cli": "^0.5.0",
     "merge-stream": "^0.1.8",
     "object-assign": "^3.0.0",
-    "run-sequence": "^1.1.0",
-    "through2": "^2.0.0"
+    "run-sequence": "^1.1.0"
   },
   "files": [
     "LICENSE",
@@ -33,8 +32,7 @@
     "flow/",
     "index.js",
     "lib/",
-    "module-map.json",
-    "scripts/"
+    "module-map.json"
   ],
   "jest": {
     "modulePathIgnorePatterns": [

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,17 @@
+# fbjs-scripts
+
+This is a collection of tools and scripts intended to be used in conjunction with `fbjs`. Previously these were shipped as a part of `fbjs`.
+
+```js
+// before (fbjs@0.1.0)
+var invariant = require('fbjs/lib/invariant');
+var devExpression = require('fbjs/scripts/babel/dev-expression');
+
+// after (fbjs, fbjs-scripts@0.2.0)
+var invariant = require('fbjs/lib/invariant');
+var devExpression = require('fbjs-scripts/babel/dev-expression');
+```
+
+## Why?
+
+This ensures that production code consuming `fbjs` library code does not need to install script dependencies, unless you explicitly use them via the `fbjs-scripts` package.

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fbjs-scripts",
+  "version": "0.2.0-alpha1",
+  "description": "A bundle of helpful scripts used in projects consuming fbjs.",
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "babel": "^5.4.7",
+    "core-js": "^1.0.0",
+    "gulp-util": "^3.0.4",
+    "object-assign": "^3.0.0",
+    "through2": "^2.0.0"
+  }
+}


### PR DESCRIPTION
Not quite done but gets the plan across. The problem I'm trying to solve here is make it possible to ship more and more support scripts without bloating the production dependencies (eg, lint is coming). Everything I moved from `devDependencies` into fbjs-scripts actually should have been a regular dependency of fbjs (but wasn't so using some scripts was actually broken). The flow stuff sits somewhere in between so I just left it as something that gets shipped with fbjs.

This uses `file:scripts` to pull in `fbjs-scripts` as a package without having to hit npm. This will also let us make changes to fbjs tooling without having to ship it to npm to actually use it, then we can ship it when it's ready. Changes will need 'npm install ./scripts' to be run (since it's copied, but I think this might be more sustainable than linking).

Any thoughts on this @yungsters, @steveluscher?

Fixes #34 