### PR TITLE
Fix import to require `babel-core`

### DIFF
--- a/scripts/babel/inline-requires.js
+++ b/scripts/babel/inline-requires.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-var t = require('babel').types;
+var t = require('babel-core').types;
 
 /**
  * Variable names associated with top level required modules.


### PR DESCRIPTION
For some reason, `npm link` didn't have an issue with this. I made sure that this works by monkey-patching the install of alpha11 inside of Relay.