### PR TITLE
Port dev engines script from React

### DIFF
--- a/scripts/node/check-dev-engines.js
+++ b/scripts/node/check-dev-engines.js
@@ -1,0 +1,62 @@
+'use strict';
+
+var fs = require('fs');
+var assert = require('assert');
+var exec = require('child_process').exec;
+var semver = require('semver');
+var f = require('util').format;
+
+// Make sure we have a package.json to parse. Take it as the first argument
+// (actually the 3rd for argv).
+var argv = process.argv;
+assert(
+  process.argv.length >= 3,
+  'Expected to receive a package.json file argument to parse'
+);
+
+var packageFilePath = process.argv[2];
+var packageData;
+try {
+  var packageFile = fs.readFileSync(packageFilePath, {encoding: 'utf-8'});
+  packageData = JSON.parse(packageFile);
+} catch (e) {
+  assert(
+    false,
+    f('Expected to be able to parse %s as JSON but we got this error instead: %s', packageFilePath, e)
+  )
+}
+
+var devEngines = packageData.devEngines;
+
+if (devEngines.node !== undefined) {
+  // First check that devEngines are valid semver
+  assert(
+    semver.validRange(devEngines.node),
+    f('devEngines.node (%s) is not a valid semver range', devEngines.node)
+  );
+  // Then actually check that our version satisfies
+  var nodeVersion = process.versions.node;
+  assert(
+    semver.satisfies(nodeVersion, devEngines.node),
+    f('Current node version is not supported for development, expected "%s" to satisfy "%s".', nodeVersion, devEngines.node)
+  );
+}
+
+if (devEngines.npm !== undefined) {
+  // First check that devEngines are valid semver
+  assert(
+    semver.validRange(devEngines.npm),
+    f('devEngines.npm (%s) is not a valid semver range', devEngines.npm)
+  );
+
+  // Then actually check that our version satisfies
+  exec('npm --version', function(err, stdout, stderr) {
+    assert(err === null, f('Failed to get npm version... %s'), stderr);
+
+    var npmVersion = stdout.trim();
+    assert(
+      semver.satisfies(npmVersion, devEngines.npm),
+      f('Current npm version is not supported for development, expected "%s" to satisfy "%s".', npmVersion, devEngines.npm)
+    );
+  });
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,6 +8,7 @@
     "core-js": "^1.0.0",
     "gulp-util": "^3.0.4",
     "object-assign": "^3.0.0",
+    "semver": "^5.0.1",
     "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
This brings in the script that we're using in React to make sure the dev environment is what we expect. It's slightly modified to require a file argument since we can't hardcode the path to the `package.json` that we want to use. Specifically it checks `devEngines` in package.json, which is something I made up (but correlates nicely with the `engines` field that npm sort of uses)

I confirmed this is working in React with
```json
"scripts": {
  "preinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json"
}
```