### PR TITLE
Eslint base config

### DIFF
--- a/scripts/eslint/.eslintrc
+++ b/scripts/eslint/.eslintrc
@@ -1,0 +1,340 @@
+---
+parser: babel-eslint
+
+env:
+  browser: true
+  node: true
+  jest: true
+  jasmine: true
+  es6: true
+
+globals:
+  __DEV__: true
+
+rules:
+  # Possible Errors <http://eslint.org/docs/rules/#possible-errors>
+  # babel removes them for older browsers, we should do a codemod
+  comma-dangle: [0, always-multiline]
+  # equivalent to jshint boss
+  no-cond-assign: 0
+  # equivalent to jshint devel
+  no-console: 0
+  # prohibits things like `while (true)`
+  no-constant-condition: 0
+  # we need to be able to match these
+  no-control-regex: 0
+  # equivalent to jshint debug
+  no-debugger: 2
+  # equivalent to jshint W004
+  no-dupe-args: 2
+  # syntax error in strict mode, almost certainly unintended in any case
+  no-dupe-keys: 2
+  # almost certainly a bug
+  no-duplicate-case: 1
+  # almost certainly a bug
+  no-empty-character-class: 1
+  # would warn on uncommented empty `catch (ex) {}` blocks
+  no-empty: 0
+  # can cause subtle bugs in IE 8, and we shouldn't do this anyways
+  no-ex-assign: 1
+  # we shouldn't do this anyways
+  no-extra-boolean-cast: 1
+  # parens may be used to improve clarity, equivalent to jshint W068
+  no-extra-parens: [1, functions]
+  # equivalent to jshint W032
+  no-extra-semi: 1
+  # a function delaration shouldn't be rewritable
+  no-func-assign: 2
+  # babel and es6 allow block-scoped functions
+  no-inner-declarations: 0
+  # will cause a runtime error
+  no-invalid-regexp: 1
+  # disallow non-space or tab whitespace characters
+  no-irregular-whitespace: 1
+  # write `if (!(a in b))`, not `if (!a in b)`, equivalent to jshint W007
+  no-negated-in-lhs: 2
+  # will cause a runtime error
+  no-obj-calls: 2
+  # improves legibility
+  no-regex-spaces: 1
+  # we target es6!
+  no-reserved-keys: 0
+  # equivalent to jshint elision
+  no-sparse-arrays: 2
+  # equivalent to jshint W027
+  no-unreachable: 2
+  # equivalent to jshint use-isnan
+  use-isnan: 2
+  # probably too noisy ATM
+  valid-jsdoc: 0
+  # equivalent to jshint notypeof
+  valid-typeof: 2
+  # we already require semicolons
+  no-unexpected-multiline: 0
+
+  # Best Practices <http://eslint.org/docs/rules/#best-practices>
+  # probably a bug, we shouldn't actually even use this yet, because of IE8
+  accessor-pairs: [1, {setWithoutGet: true}]
+  # probably too noisy ATM
+  block-scoped-var: 0
+  # cyclomatic complexity, we're too far gone
+  complexity: 0
+  # require return statements to either always or never specify values
+  consistent-return: 1
+  # style guide: Always use brackets, even when optional.
+  curly: [2, all]
+  # we don't do this/care about this
+  default-case: 0
+  # disabled in favor of our temporary fork
+  dot-notation: 0
+  # we don't do this/care about this, but probably should eventually
+  dot-location: 0
+  # disabled as it's too noisy ATM
+  eqeqeq: [0, allow-null]
+  # we don't do this/care about this, equivalent to jshint forin
+  guard-for-in: 0
+  # we have too many internal examples/tools using this
+  no-alert: 0
+  # incompatible with use strict equivalent to jshint noarg
+  no-caller: 2
+  # we don't do this/care about this
+  no-div-regex: 0
+  # we don't do this/care about this
+  no-else-return: 0
+  # equivalent to jshint W028
+  no-empty-label: 2
+  # see eqeqeq: we explicitly allow this, equivalent to jshint eqnull
+  no-eq-null: 0
+  # equivalent to jshint evil
+  no-eval: 2
+  # should only be triggered on polyfills, which we can fix case-by-case
+  no-extend-native: 1
+  # might be a sign of a bug
+  no-extra-bind: 1
+  # equivalent to jshint W089
+  no-fallthrough: 1
+  # equivalent to jshint W008
+  no-floating-decimal: 2
+  # implicit coercion is often idiomatic
+  no-implicit-coercion: 0
+  # equivalent to jshint evil/W066
+  no-implied-eval: 2
+  # will likely create more signal than noise
+  no-invalid-this: 0
+  # babel should handle this fine
+  no-iterator: 0
+  # this is occasionally useful, and jshint allowed it
+  no-labels: 0
+  # lone blocks create no scope, will ignore blocks with let/const
+  no-lone-blocks: 1
+  # equivalent to jshint loopfunc
+  no-loop-func: 0
+  # we may use this for alignment in some places
+  no-multi-spaces: 0
+  # equivalent to jshint multistr, consider using es6 template strings
+  no-multi-str: 2
+  # equivalent to jshint W020, similar to no-extend-native
+  no-native-reassign: [2, {exceptions: [Map, Set]}]
+  # equivalent to jshint evil/W054
+  no-new-func: 2
+  # don't use constructors for side-effects, equivalent to jshint nonew
+  no-new: 1
+  # deprecated in ES5, but we still use it in some places
+  no-octal-escape: 1
+  # deprecated in ES5, may cause unexpected behavior
+  no-octal: 1
+  # treats function parameters as constants, probably too noisy ATM
+  no-param-reassign: 0
+  # only relevant to node code
+  no-process-env: 0
+  # deprecated in ES3.1, equivalent to jshint proto
+  no-proto: 2
+  # jshint doesn't catch this, but this is inexcusable
+  no-redeclare: 1
+  # equivalent to jshint boss
+  no-return-assign: 0
+  # equivalent to jshint scripturl
+  no-script-url: 2
+  # not in jshint, but is in jslint, and is almost certainly a mistake
+  no-self-compare: 1
+  # there are very limited valid use-cases for this
+  no-sequences: 1
+  # we're already pretty good about this, and it hides stack traces
+  no-throw-literal: 1
+  # breaks on `foo && foo.bar()` expression statements, which are common
+  no-unused-expressions: 0
+  # disallow unnecessary .call() and .apply()
+  no-useless-call: 1
+  # this has valid use-cases, eg. to circumvent no-unused-expressions
+  no-void: 0
+  # this journey is 1% finished (allow TODO comments)
+  no-warning-comments: 0
+  # equivalent to jshint withstmt
+  no-with: 0
+  # require radix argument in parseInt, we do this in most places already
+  radix: 1
+  # we don't do this/care about this
+  vars-on-top: 0
+  # equivalent to jshint immed
+  wrap-iife: 0
+  # probably too noisy ATM
+  yoda: 0
+
+  # Strict Mode <http://eslint.org/docs/rules/#strict-mode>
+  # jshint wasn't checking this, and the compiler should add this anyways
+  strict: 0
+
+  # Variables <http://eslint.org/docs/rules/#variables>
+  # we don't do this/care about this
+  init-declarations: 0
+  # equivalent to jshint W002, catches an IE8 bug
+  no-catch-shadow: 2
+  # equivalent to jshint W051, is a strict mode violation
+  no-delete-var: 2
+  # we should avoid labels anyways
+  no-label-var: 1
+  # redefining undefined, NaN, Infinity, arguments, and eval is bad, mkay?
+  no-shadow-restricted-names: 1
+  # a definite code-smell, but probably too noisy
+  no-shadow: 0
+  # it's nice to be explicit sometimes: `var foo = undefined;`
+  no-undef-init: 0
+  # equivalent to jshint undef, turned into an error in getConfig
+  # NOTE: This diverges from internal - just turned into an error here since we
+  # almost always do that anyway.
+  no-undef: 2
+  # using undefined is safe because we enforce no-shadow-restricted-names
+  no-undefined: 0
+  # equivalent to jshint unused
+  no-unused-vars: [1, {args: none}]
+  # too noisy
+  no-use-before-define: 0
+
+  # Node.js <http://eslint.org/docs/rules/#nodejs>
+  # TODO: turn some of these on in places where we lint node code
+  callback-return: 0
+  handle-callback-err: 0
+  no-mixed-requires: 0
+  no-new-require: 0
+  no-path-concat: 0
+  no-process-exit: 0
+  no-restricted-modules: 0
+  no-sync: 0
+
+  # Stylistic Issues <http://eslint.org/docs/rules/#stylistic-issues>
+  # See also: https://our.intern.facebook.com/intern/dex/style-guide/
+  array-bracket-spacing: 1
+  brace-style: [1, 1tbs, {allowSingleLine: true}]
+  # too noisy at the moment, and jshint didn't check it
+  camelcase: [0, {properties: always}]
+  comma-spacing: [1, {before: false, after: true}]
+  # jshint had laxcomma, but that was against our style guide
+  comma-style: [1, last]
+  computed-property-spacing: [1, never]
+  # we may use more contextually relevant names for this than self
+  consistent-this: [0, self]
+  # should be handled by a generic TXT linter instead
+  eol-last: 0
+  func-names: 0
+  # too noisy ATM
+  func-style: [0, declaration]
+  # we weren't enforcing this with jshint, so erroring would be too noisy
+  indent: [1, 2, {SwitchCase: 1}]
+  # we may use extra spaces for alignment
+  key-spacing: [0, {beforeColon: false, afterColon: true}]
+  lines-around-comment: 0
+  # should be handled by a generic TXT linter instead
+  linebreak-style: [0, unix]
+  max-nested-callbacks: 0
+  # https://facebook.com/groups/995898333776940/1027358627297577
+  new-cap: 0
+  # equivalent to jshint W058
+  new-parens: 2
+  newline-after-var: 0
+  # equivalent to FacebookWebJSLintLinter's checkPhpStyleArray
+  no-array-constructor: 2
+  no-continue: 0
+  no-inline-comments: 0
+  # doesn't play well with `if (__DEV__) {}`
+  no-lonely-if: 0
+  # stopgap, irrelevant if we can eventually turn `indent` on to error
+  no-mixed-spaces-and-tabs: 2
+  # we do this a bunch of places, and it's less bad with proper indentation
+  no-nested-ternary: 0
+  # similar to FacebookWebJSLintLinter's checkPhpStyleArray
+  no-new-object: 1
+  no-spaced-func: 1
+  no-ternary: 0
+  # should be handled by a generic TXT linter instead
+  no-trailing-spaces: 0
+  # we use this for private/protected identifiers
+  no-underscore-dangle: 0
+  # disallow `var isYes = answer === 1 ? true : false;`
+  no-unneeded-ternary: 1
+  # too noisy ATM
+  object-curly-spacing: 0
+  # makes indentation warnings clearer
+  one-var: [1, {initialized: never}]
+  # prefer `x += 4` over `x = x + 4`
+  operator-assignment: [1, always]
+  # equivalent to jshint laxbreak
+  operator-linebreak: 0
+  padded-blocks: 0
+  # probably too noisy on pre-ES5 code
+  quote-props: [0, as-needed]
+  quotes: [1, single, avoid-escape]
+  semi-spacing: [1, {before: false, after: true}]
+  # equivalent to jshint asi/W032
+  semi: [1, always]
+  sort-vars: 0
+  # require `if ()` instead of `if()`
+  space-after-keywords: [1, always]
+  # require `if () {` instead of `if (){`
+  space-before-blocks: [1, always]
+  # require `function foo()` instead of `function foo ()`
+  space-before-function-paren: [1, {anonymous: never, named: never}]
+  space-in-parens: [1, never]
+  space-infix-ops: 0
+  # require `return -a` instead of `return-a`
+  space-return-throw-case: 1
+  # Currently broken: https://github.com/eslint/eslint/issues/2764
+  space-unary-ops: [0, {words: true, nonwords: false}]
+  # TODO: Figure out a way to do this that doesn't break typechecks
+  # or wait for https://github.com/eslint/eslint/issues/2897
+  spaced-comment: [0, always, {exceptions: [jshint, jslint, eslint, global]}]
+  wrap-regex: 0
+
+  # ECMAScript 6 <http://eslint.org/docs/rules/#ecmascript-6>
+  # TODO: our style guide says to always use parens, even w/ a single param
+  arrow-parens: 0
+  # tbgs finds *very few* places where we don't put spaces around =>
+  arrow-spacing: [1, {before: true, after: true}]
+  # violation of the ES6 spec, won't transform
+  constructor-super: 2
+  # https://github.com/babel/babel-eslint#known-issues
+  generator-star-spacing: 0
+  no-class-assign: 1
+  # this is a runtime error
+  no-const-assign: 2
+  # violation of the ES6 spec, won't transform, `this` is part of the TDZ
+  no-this-before-super: 2
+  # we have way too much ES3 & ES5 code
+  no-var: 0
+  object-shorthand: 0
+  # will only impact future ES6 code that'll use let
+  prefer-const: 1
+  prefer-spread: 0
+  # we don't support/polyfill this yet
+  prefer-reflect: 0
+  # there are legitimate use-cases for an empty generator
+  require-yield: 0
+
+  # Legacy <http://eslint.org/docs/rules/#legacy>
+  max-depth: 0
+  # TODO: replace regexp linter with this, using {ignorePattern}
+  max-len: 0
+  max-params: 0
+  max-statements: 0
+  no-bitwise: 1
+  no-plusplus: 0
+


### PR DESCRIPTION
This pulls in out internal eslint config into something we can start using in downstream projects with minimal overrides (eg we're a bit stricter in React but probably don't want to be in Relay). We can continue down this path and bring in some custom rules next - we have a number of internal ones that were written and would be good to have out here to maintain consistency.

Note: this was branched from #48 so it has that totally unrelated dev engines script.