### PR TITLE
Ignore `config` option when creating a cache key.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "whatwg-fetch": "^0.9.0"
   },
   "devEngines": {
-    "node": "3.x",
+    "node": ">=3",
     "npm": "2.x"
   }
 }

--- a/scripts/jest/createCacheKeyFunction.js
+++ b/scripts/jest/createCacheKeyFunction.js
@@ -31,10 +31,10 @@ var cacheKeyBase = buildCacheKey(cacheKeyFiles, '');
 module.exports = function(files) {
   var cacheKey = buildCacheKey(files, cacheKeyBase);
 
-  return function() {
+  return function(src, file, options, excludes) {
     return crypto.createHash('md5')
       .update(cacheKey)
-      .update(JSON.stringify(arguments))
+      .update(JSON.stringify([src, file, options, excludes]))
       .digest('hex');
   };
 };


### PR DESCRIPTION
We don't need it because it can't influence the output of a test file. It is also not being stringified consistently and results in more cache misses than necessary.