### PR TITLE
[fetch] Correctly reject final try on error

### DIFF
--- a/src/fetch/fetchWithRetries.js
+++ b/src/fetch/fetchWithRetries.js
@@ -86,7 +86,12 @@ function fetchWithRetries(
             retryRequest();
           } else {
             // Request was not successful, giving up.
-            reject(response);
+            var error: any = new Error(sprintf(
+                'fetchWithRetries(): Got an error as a final response from ' +
+                'server, tried %s times.',
+            ));
+            error.response = response;
+            reject(error);
           }
         }
       }).catch(error => {


### PR DESCRIPTION
Correctly reject the promise if the final `fetch`-attempt returned with an HTTP
status not between 200 and 299. The error will have an extra property `response`
which stores the response `fetch` returned.

Fixes https://github.com/facebook/relay/issues/347