### PR TITLE
Ensure fetchWithRetries is rejected with an Error

### DIFF
--- a/src/fetch/fetchWithRetries.js
+++ b/src/fetch/fetchWithRetries.js
@@ -86,7 +86,13 @@ function fetchWithRetries(
             retryRequest();
           } else {
             // Request was not successful, giving up.
-            reject(response);
+            var error: any = new Error(sprintf(
+              'fetchWithRetries(): Still no successful response after ' +
+              '%s retries, giving up.',
+              requestsAttempted
+            ));
+            error.response = response;
+            reject(error);
           }
         }
       }).catch(error => {


### PR DESCRIPTION
After the last retry fails, the Promise should be rejected with an `Error` instead of the fetch `Response` object.
This will parse the body and append it to the returned `Error` object.

Fixes https://github.com/facebook/relay/issues/347