### PR TITLE
Make tests pass on none facebook stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "babel": "^5.4.7",
+    "core-js": "^1.1.4",
     "del": "^1.2.0",
     "fbjs-scripts": "file:scripts",
     "flow-bin": "^0.14.0",

--- a/scripts/babel/default-options.js
+++ b/scripts/babel/default-options.js
@@ -31,6 +31,7 @@ module.exports = {
   stage: 1,
   plugins: plugins,
   _moduleMap: {
+    'core-js/es6': 'core-js/es6',
     'core-js/library/es6/map': 'core-js/library/es6/map',
     'promise': 'promise',
     'whatwg-fetch': 'whatwg-fetch'


### PR DESCRIPTION
Running `npm test` would fail with an error "Cannot find module './core-js/es6'
from '/fbjs/scripts/jest/environment.js'" Add `core-js` as a dev-dependency and
add it to the modules not being touched by the "rewrite modules"-script.