### PR TITLE
Fix getActiveElement so that it does not throw error

### DIFF
--- a/src/core/__tests__/dom/getActiveElement-test.js
+++ b/src/core/__tests__/dom/getActiveElement-test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+jest.dontMock('getActiveElement');
+
+var getActiveElement = require('getActiveElement');
+
+describe('getActiveElement', () => {
+  it('returns body when there is no activeElement', () => {
+    var element = getActiveElement();
+    expect(element.tagName).toEqual('BODY');
+  });
+});

--- a/src/core/dom/getActiveElement.js
+++ b/src/core/dom/getActiveElement.js
@@ -14,9 +14,13 @@
  * Same as document.activeElement but wraps in a try-catch block. In IE it is
  * not safe to call document.activeElement if there is nothing focused.
  *
- * The activeElement will be null only if the document body is not yet defined.
+ * The activeElement will be null only if the document or document body is not yet defined.
  */
 function getActiveElement() /*?DOMElement*/ {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
   try {
     return document.activeElement || document.body;
   } catch (e) {


### PR DESCRIPTION
 when `document` does not exist

While using great library `react-unit` to test the React components I discovered that this function is the only part that needs `document` global otherwise it crashes (variable not defined). This is an attempt to make it work even without document.

I've added simple test to verify basic functionality, but haven't figure out how to test my scenario when `document` is not present.

Thanks a lot and looking forward for the feedback...