### PR TITLE
Switch to isomorphic-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
   },
   "dependencies": {
     "core-js": "^1.0.0",
-    "promise": "^7.0.3",
-    "whatwg-fetch": "^0.9.0"
+    "isomorphic-fetch": "^2.1.1",
+    "promise": "^7.0.3"
   },
   "devEngines": {
     "node": ">=3",

--- a/scripts/babel/default-options.js
+++ b/scripts/babel/default-options.js
@@ -33,6 +33,6 @@ module.exports = {
   _moduleMap: {
     'core-js/library/es6/map': 'core-js/library/es6/map',
     'promise': 'promise',
-    'whatwg-fetch': 'whatwg-fetch'
+    'isomorphic-fetch': 'isomorphic-fetch'
   }
 };

--- a/src/__forks__/fetch.js
+++ b/src/__forks__/fetch.js
@@ -11,5 +11,11 @@
 
 'use strict';
 
-require('whatwg-fetch');
-module.exports = self.fetch.bind(self);
+// This hopefully supports the React Native case, which is already bringing along
+// its own fetch polyfill. That should exist on `global`. If that doesn't exist
+// then we'll try to polyfill, which might not work correctly in all environments.
+if (global.fetch) {
+  module.exports = global.fetch.bind(global);
+} else {
+  module.exports = require('isomorphic-fetch');
+}


### PR DESCRIPTION
Fixes #60 

This should be pretty safe. With browserify and webpack packaging, this will use whatwg-fetch (exactly the same code we had).