### PR TITLE
Bring in some modules from React

### DIFF
--- a/src/core/__tests__/joinClasses-test.js
+++ b/src/core/__tests__/joinClasses-test.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+
+'use strict';
+
+require('mock-modules').dontMock('joinClasses');
+
+var joinClasses = require('joinClasses');
+
+describe('joinClasses', function() {
+
+  it('should return a single className', function() {
+    expect(joinClasses('aaa')).toEqual('aaa');
+  });
+
+  it('should join two classes together', function() {
+    var aaa = 'aaa';
+    var bbb = 'bbb';
+    expect(joinClasses(aaa, bbb)).toEqual('aaa bbb');
+  });
+
+  it('should join many classes together', function() {
+    var aaa = 'aaa';
+    var bbb = 'bbb';
+    var ccc = 'ccc';
+    var ddd = 'ddd';
+    var eee = 'eee';
+    expect(joinClasses(aaa, bbb, ccc, ddd, eee)).toEqual('aaa bbb ccc ddd eee');
+  });
+
+  it('should omit undefined and empty classes', function() {
+    var aaa = 'aaa';
+    var bbb;
+    var ccc = null;
+    var ddd = '';
+    var eee = 'eee';
+    expect(joinClasses(bbb)).toEqual('');
+    expect(joinClasses(bbb, bbb, bbb)).toEqual('');
+    expect(joinClasses(aaa, bbb, ccc, ddd, eee)).toEqual('aaa eee');
+  });
+
+});

--- a/src/core/__tests__/memoizeStringOnly-test.js
+++ b/src/core/__tests__/memoizeStringOnly-test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+
+'use strict';
+
+describe('memoizeStringOnly', function() {
+  var memoizeStringOnly;
+
+  beforeEach(function() {
+    require('mock-modules').dumpCache();
+    memoizeStringOnly = require('memoizeStringOnly');
+  });
+
+  it('should be transparent to callers', function() {
+    var callback = function(string) {
+      return string;
+    };
+    var memoized = memoizeStringOnly(callback);
+
+    expect(memoized('foo'), callback('foo'));
+  });
+});

--- a/src/core/joinClasses.js
+++ b/src/core/joinClasses.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule joinClasses
+ * @typechecks static-only
+ */
+
+'use strict';
+
+/**
+ * Combines multiple className strings into one.
+ * http://jsperf.com/joinclasses-args-vs-array
+ *
+ * @param {...?string} className
+ * @return {string}
+ */
+function joinClasses(className/*, ... */) {
+  if (!className) {
+    className = '';
+  }
+  var nextClass;
+  var argLength = arguments.length;
+  if (argLength > 1) {
+    for (var ii = 1; ii < argLength; ii++) {
+      nextClass = arguments[ii];
+      if (nextClass) {
+        className = (className ? className + ' ' : '') + nextClass;
+      }
+    }
+  }
+  return className;
+}
+
+module.exports = joinClasses;

--- a/src/core/memoizeStringOnly.js
+++ b/src/core/memoizeStringOnly.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule memoizeStringOnly
+ * @typechecks static-only
+ */
+
+'use strict';
+
+/**
+ * Memoizes the return value of a function that accepts one string argument.
+ *
+ * @param {function} callback
+ * @return {function}
+ */
+function memoizeStringOnly(callback) {
+  var cache = {};
+  return function(string) {
+    if (!cache.hasOwnProperty(string)) {
+      cache[string] = callback.call(this, string);
+    }
+    return cache[string];
+  };
+}
+
+module.exports = memoizeStringOnly;


### PR DESCRIPTION
Wanted to move a couple things our of React. I just threw them in core like everybody else but they can be moved later (the important part is getting them out of React). There are certainly more but these came up in a couple discussions recently.

Note: I still need to do this internally and we'll have to do a diff to React to remove and update the fbjs dep. It would be safe to land this and not update React immediately (they'll be under completely different paths after compilation).

`memoizeStringOnly` is used by UserAgent (#57 commented out in the code there)

`joinClasses` is used by a bunch of components and surely non-React code and I'd rather not map them into React if we open source any of them. Not to mention that there is nothing React specific about it.

cc @yungsters @spicyj 