### PR TITLE
browserify friendliness

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "LICENSE",
     "PATENTS",
     "README.md",
-    "flow/lib",
+    "flow/",
     "index.js",
     "lib/",
     "module-map.json"
@@ -57,11 +57,17 @@
   },
   "dependencies": {
     "core-js": "^1.0.0",
+    "loose-envify": "^1.0.0",
     "promise": "^7.0.3",
     "whatwg-fetch": "^0.9.0"
   },
   "devEngines": {
     "node": ">=3",
     "npm": "2.x"
+  },
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "LICENSE",
     "PATENTS",
     "README.md",
-    "flow/",
+    "flow/lib",
     "index.js",
     "lib/",
     "module-map.json"


### PR DESCRIPTION
* https://github.com/facebook/react/commit/6fc53e043876f5b53b144847faaeb7ea4398f9c3#diff-c3a9ce50ac626f89fa72fdcb514bf9e9R110 works fine for building the dist `react.js`, but users who `require('react')` aren't getting fbjs envified. So someone using browserify is getting the `process` shim included, which is like 2kb and has an empty env – so `process.env.NODE_ENV !== 'production'` is always true for fbjs stuff. I took the liberty of using `loose-envify` because it's fast (I'm using it in [invariant](https://github.com/zertosh/invariant) already) – but feel free to remove it in favor of the actual envify.

<del>* Even though `flow/include` is in `.gitignore`, because `"files"` is used (instead of `.npmignore`), the published package includes it.</del>
