### PR TITLE
Enable `comma-dangle` as an eslint warning

### DIFF
--- a/scripts/eslint/.eslintrc
+++ b/scripts/eslint/.eslintrc
@@ -38,7 +38,7 @@ globals:
 rules:
   # Possible Errors <http://eslint.org/docs/rules/#possible-errors>
   # babel removes them for older browsers, we should do a codemod
-  comma-dangle: [0, always-multiline]
+  comma-dangle: [1, always-multiline]
   # equivalent to jshint boss
   no-cond-assign: 0
   # equivalent to jshint devel


### PR DESCRIPTION
Enabling `comma-dangle` to warn if there is a missing trailing comma on arrays or objects that span multiple lines, and warn if there is a trailing comma present on single line arrays or objects.

Trailing commas simplify adding and removing items to objects and arrays, since only the lines you are modifying must be touched.

> This commit message was shamelessly jacked from [the ESLint website](http://eslint.org/docs/rules/comma-dangle.html).