### PR TITLE
"Invariant Violation" as Error Name

### DIFF
--- a/src/__forks__/invariant.js
+++ b/src/__forks__/invariant.js
@@ -22,7 +22,7 @@
  * will remain to ensure logic does not differ in production.
  */
 
-var invariant = function(condition, format, a, b, c, d, e, f) {
+function invariant(condition, format, a, b, c, d, e, f) {
   if (__DEV__) {
     if (format === undefined) {
       throw new Error('invariant requires an error message argument');
@@ -40,14 +40,14 @@ var invariant = function(condition, format, a, b, c, d, e, f) {
       var args = [a, b, c, d, e, f];
       var argIndex = 0;
       error = new Error(
-        'Invariant Violation: ' +
         format.replace(/%s/g, function() { return args[argIndex++]; })
       );
+      error.name = 'Invariant Violation';
     }
 
     error.framesToPop = 1; // we don't care about invariant's own frame
     throw error;
   }
-};
+}
 
 module.exports = invariant;

--- a/src/core/__tests__/PromiseMap-test.js
+++ b/src/core/__tests__/PromiseMap-test.js
@@ -15,12 +15,11 @@
 
 jest.dontMock('PromiseMap');
 
-describe('PromiseMap', () => {
-  var PromiseMap;
+var PromiseMap = require('PromiseMap');
 
+describe('PromiseMap', () => {
   beforeEach(() => {
     jest.resetModuleRegistry();
-    PromiseMap = require('PromiseMap');
   });
 
   it('can get a value after resolving it', () => {
@@ -111,7 +110,7 @@ describe('PromiseMap', () => {
 
     expect(() => {
       map.resolveKey('foo', 1337);
-    }).toThrow('Invariant Violation: PromiseMap: Already settled `foo`.');
+    }).toThrow('PromiseMap: Already settled `foo`.');
 
     map.get('foo').then(value => {
       getValue = value;
@@ -130,7 +129,7 @@ describe('PromiseMap', () => {
 
     expect(() => {
       map.rejectKey('foo', 1337);
-    }).toThrow('Invariant Violation: PromiseMap: Already settled `foo`.');
+    }).toThrow('PromiseMap: Already settled `foo`.');
 
     map.get('foo').catch(value => {
       getValue = value;
@@ -149,7 +148,7 @@ describe('PromiseMap', () => {
 
     expect(() => {
       map.rejectKey('foo', 1337);
-    }).toThrow('Invariant Violation: PromiseMap: Already settled `foo`.');
+    }).toThrow('PromiseMap: Already settled `foo`.');
 
     map.get('foo').then(value => {
       getValue = value;


### PR DESCRIPTION
Gets rid of the "Invariant Violation: " message prefix in favor of setting the `error.name` to "Invariant Violation".