### PR TITLE
Update to jest 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
     "gulp-flatten": "^0.2.0",
-    "jest-cli": "^0.5.0",
+    "jest-cli": "^0.6.0",
     "merge-stream": "^1.0.0",
     "object-assign": "^4.0.1",
     "run-sequence": "^1.1.0"

--- a/scripts/jest/createCacheKeyFunction.js
+++ b/scripts/jest/createCacheKeyFunction.js
@@ -7,34 +7,34 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-var crypto = require('crypto');
-var fs = require('fs');
-var path = require('path');
+ 'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
 
 function buildCacheKey(files, base) {
-  return files.reduce(function(src, fileName) {
-    return src + fs.readFileSync(fileName);
-  }, base);
+  return files.reduce(
+    (src, fileName) => src + fs.readFileSync(fileName),
+    base
+  );
 }
 
-var transformRoot = path.join(__dirname, '..');
-var cacheKeyFiles = [
+const transformRoot = path.join(__dirname, '..');
+const cacheKeyFiles = [
   __filename,
-  path.join(transformRoot, 'babel/default-options.js'),
-  path.join(transformRoot, 'babel/dev-expression.js'),
-  path.join(transformRoot, 'babel/inline-requires.js'),
-  path.join(transformRoot, 'babel/rewrite-modules.js'),
+  path.join(transformRoot, 'babel', 'default-options.js'),
+  path.join(transformRoot, 'babel', 'dev-expression.js'),
+  path.join(transformRoot, 'babel', 'inline-requires.js'),
+  path.join(transformRoot, 'babel', 'rewrite-modules.js'),
 ];
 
-var cacheKeyBase = buildCacheKey(cacheKeyFiles, '');
+const cacheKeyBase = buildCacheKey(cacheKeyFiles, '');
 
-module.exports = function(files) {
-  var cacheKey = buildCacheKey(files, cacheKeyBase);
-
-  return function(src, file, options, excludes) {
-    return crypto.createHash('md5')
-      .update(cacheKey)
-      .update(JSON.stringify([src, file, options, excludes]))
-      .digest('hex');
-  };
+module.exports = files => {
+  const cacheKey = buildCacheKey(files, cacheKeyBase);
+  return (src, file, configString) => crypto.createHash('md5')
+    .update(cacheKey)
+    .update(src + file + configString)
+    .digest('hex');
 };

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -7,13 +7,15 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-var assign = require('object-assign');
-var babel = require('babel');
-var babelDefaultOptions = require('../babel/default-options');
-var createCacheKeyFunction = require('./createCacheKeyFunction');
+'use strict';
+
+const assign = require('object-assign');
+const babel = require('babel');
+const babelDefaultOptions = require('../babel/default-options');
+const createCacheKeyFunction = require('./createCacheKeyFunction');
 
 module.exports = {
-  process: function(src, filename) {
+  process(src, filename) {
     return babel.transform(src, assign(
       {},
       babelDefaultOptions,


### PR DESCRIPTION
updated createCacheKeyFunction to use the correct config object for creating the hash; this was a breaking change in jest.