### PR TITLE
[babel] Add auto-importer transform

### DIFF
--- a/scripts/babel-6/auto-importer.js
+++ b/scripts/babel-6/auto-importer.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var MODULES = [
+  // Local Promise implementation.
+  'Promise',
+];
+
+/**
+ * Automatically imports a module if its identifier is in the AST.
+ */
+module.exports = function autoImporter(babel) {
+
+  var t = babel.types;
+
+  function isAppropriateModule(name, scope, state) {
+    var autoImported = state.autoImported;
+    return MODULES.indexOf(name) !== -1
+        && !autoImported.hasOwnProperty(name)
+        && !scope.hasBinding(name, /*skip globals*/true);
+  }
+
+  return {
+    pre: function() {
+      // Cache per file to avoid calling `scope.hasBinding` several
+      // times for the same module, which has already been auto-imported.
+      this.autoImported = {};
+    },
+
+    visitor: {
+      ReferencedIdentifier: function(path) {
+        var node = path.node;
+        var scope = path.scope;
+
+        if (!isAppropriateModule(node.name, scope, this)) {
+          return;
+        }
+
+        scope.getProgramParent().push({
+          id: t.identifier(node.name),
+          init: t.callExpression(
+            t.identifier('require'),
+            [t.stringLiteral(node.name)]
+          ),
+        });
+
+        this.autoImported[node.name] = true;
+      },
+    }
+  };
+};

--- a/scripts/babel/auto-importer.js
+++ b/scripts/babel/auto-importer.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var MODULES = [
+  // Local Promise implementation.
+  'Promise',
+];
+
+/**
+ * Automatically imports a module if its identifier is in the AST.
+ */
+module.exports = function autoImporter(babel) {
+
+  var t = babel.types;
+
+  function isAppropriateModule(name, scope, state) {
+    var autoImported = state.get('autoImported');
+    return MODULES.indexOf(name) !== -1
+        && !autoImported.hasOwnProperty(name)
+        && !scope.hasBinding(name, /*skip globals*/true);
+  }
+
+  return new babel.Plugin('auto-importer', {
+    pre: function(state) {
+      // Cache per file to avoid calling `scope.hasBinding` several
+      // times for the same module, which has already been auto-imported.
+      state.set('autoImported', {});
+    },
+
+    visitor: {
+      ReferencedIdentifier: function(node, parent, scope, state) {
+        if (!isAppropriateModule(node.name, scope, state)) {
+          return node;
+        }
+
+        scope.getProgramParent().push({
+          id: t.identifier(node.name),
+          init: t.callExpression(
+            t.identifier('require'),
+            [t.literal(node.name)]
+          ),
+        });
+
+        var autoImported = state.get('autoImported');
+        autoImported[node.name] = true;
+        state.set('autoImported', autoImported);
+      },
+    }
+  });
+};

--- a/scripts/babel/default-options.js
+++ b/scripts/babel/default-options.js
@@ -10,8 +10,19 @@
 'use strict';
 
 var babelPluginModules = require('./rewrite-modules');
+var babelPluginAutoImporter = require('./auto-importer');
 var inlineRequires = require('./inline-requires');
-var plugins = [babelPluginModules];
+
+var plugins = [
+  {
+    position: 'after',
+    transformer: babelPluginAutoImporter,
+  },
+  {
+    position: 'after',
+    transformer: babelPluginModules,
+  },
+];
 
 if (process.env.NODE_ENV === 'test') {
   plugins.push({


### PR DESCRIPTION
Adds auto-importer transform (Babel 5 and 6 versions). We auto-import `Promise` module, and also `regeneratorRuntime`.