### PR TITLE
Use `warn` instead of `error` for warnings

### DIFF
--- a/src/__forks__/warning.js
+++ b/src/__forks__/warning.js
@@ -39,7 +39,7 @@ if (__DEV__) {
       var argIndex = 0;
       var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
       if (typeof console !== 'undefined') {
-        console.error(message);
+        console.warn(message);
       }
       try {
         // --- Welcome to debugging React ---


### PR DESCRIPTION
`console.warn` is both visually and semantically correct for displaying warnings than `console.error`. I recommend switching to it :+1: 