### PR TITLE
[RFC] RN 0.18 Compatibility changes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,8 @@ var runSequence = require('run-sequence');
 
 var babelPluginDEV = require('fbjs-scripts/babel/dev-expression');
 var babelDefaultOptions = require('fbjs-scripts/babel/default-options');
-var gulpModuleMap = require('fbjs-scripts/gulp/module-map.js');
+var gulpModuleMap = require('fbjs-scripts/gulp/module-map');
+var gulpStripProvidesModule = require('fbjs-scripts/gulp/strip-provides-module');
 
 var paths = {
   lib: {
@@ -50,6 +51,7 @@ gulp.task('lib', function() {
   var libTask = gulp
     .src(paths.lib.src)
     .pipe(gulpModuleMap(moduleMapOpts))
+    .pipe(gulpStripProvidesModule())
     .pipe(babel(babelOpts))
     .pipe(flatten())
     .pipe(gulp.dest(paths.lib.dest));

--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
   "dependencies": {
     "core-js": "^1.0.0",
     "loose-envify": "^1.0.0",
+    "isomorphic-fetch": "^2.1.1",
     "promise": "^7.0.3",
-    "ua-parser-js": "^0.7.9",
-    "whatwg-fetch": "^0.9.0"
+    "ua-parser-js": "^0.7.9"
   },
   "devEngines": {
     "node": ">=3",

--- a/scripts/babel/default-options.js
+++ b/scripts/babel/default-options.js
@@ -43,8 +43,8 @@ module.exports = {
   plugins: plugins,
   _moduleMap: {
     'core-js/library/es6/map': 'core-js/library/es6/map',
+    'isomorphic-fetch': 'isomorphic-fetch',
     'promise': 'promise',
     'ua-parser-js': 'ua-parser-js',
-    'whatwg-fetch': 'whatwg-fetch',
   },
 };

--- a/scripts/babel/default-options.js
+++ b/scripts/babel/default-options.js
@@ -45,6 +45,8 @@ module.exports = {
     'core-js/library/es6/map': 'core-js/library/es6/map',
     'isomorphic-fetch': 'isomorphic-fetch',
     'promise': 'promise',
+    'promise/setimmediate/done': 'promise/setimmediate/done',
+    'promise/setimmediate/es6-extensions': 'promise/setimmediate/es6-extensions',
     'ua-parser-js': 'ua-parser-js',
   },
 };

--- a/scripts/gulp/module-map.js
+++ b/scripts/gulp/module-map.js
@@ -14,7 +14,7 @@ var through = require('through2');
 var fs = require('fs');
 var path = require('path');
 
-var PM_REGEXP = /\r?\n \* \@providesModule (\S+)\r?\n/;
+var PM_REGEXP = require('./shared/provides-module').regexp;
 
 var PLUGIN_NAME = 'module-map';
 

--- a/scripts/gulp/shared/provides-module.js
+++ b/scripts/gulp/shared/provides-module.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = {
+  regexp: /\r?\n \* \@providesModule (\S+)(?=\r?\n)/,
+};

--- a/scripts/gulp/strip-provides-module.js
+++ b/scripts/gulp/strip-provides-module.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var gutil = require('gulp-util');
+var through = require('through2');
+var PM_REGEXP = require('./shared/provides-module').regexp;
+
+module.exports = function(opts) {
+  function transform(file, enc, cb) {
+    if (file.isNull()) {
+      cb(null, file);
+      return;
+    }
+
+    if (file.isStream()) {
+      cb(new gutil.PluginError('module-map', 'Streaming not supported'));
+      return;
+    }
+
+    // Get the @providesModule piece out of the file and save that.
+    var contents = file.contents.toString().replace(PM_REGEXP, '');
+    file.contents = new Buffer(contents);
+    this.push(file);
+    cb();
+  }
+
+  return through.obj(transform);
+};

--- a/src/__forks__/Promise.native.js
+++ b/src/__forks__/Promise.native.js
@@ -1,0 +1,35 @@
+/**
+ *
+ * Copyright 2013-2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * This module wraps and augments the minimally ES6-compliant Promise
+ * implementation provided by the promise npm package.
+ *
+ */
+
+'use strict';
+
+var Promise = require('promise/setimmediate/es6-extensions');
+require('promise/setimmediate/done');
+
+/**
+ * Handle either fulfillment or rejection with the same callback.
+ */
+Promise.prototype.finally = function(onSettled) {
+  return this.then(onSettled, onSettled);
+};
+
+module.exports = Promise;

--- a/src/__forks__/Promise.native.js
+++ b/src/__forks__/Promise.native.js
@@ -1,19 +1,10 @@
 /**
  *
- * Copyright 2013-2014 Facebook, Inc.
+ * Copyright 2013-2016 Facebook, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * This module wraps and augments the minimally ES6-compliant Promise
  * implementation provided by the promise npm package.

--- a/src/__forks__/fetch.js
+++ b/src/__forks__/fetch.js
@@ -11,5 +11,11 @@
 
 'use strict';
 
-require('whatwg-fetch');
-module.exports = self.fetch.bind(self);
+// This hopefully supports the React Native case, which is already bringing along
+// its own fetch polyfill. That should exist on `global`. If that doesn't exist
+// then we'll try to polyfill, which might not work correctly in all environments.
+if (global.fetch) {
+  module.exports = global.fetch.bind(global);
+} else {
+  module.exports = require('isomorphic-fetch');
+}

--- a/src/stubs/ErrorUtils.js
+++ b/src/stubs/ErrorUtils.js
@@ -11,13 +11,17 @@
 
 /* jslint unused:false */
 
-var ErrorUtils = {
-  applyWithGuard(callback, context, args, onError, name) {
-    return callback.apply(context, args);
-  },
-  guard(callback, name) {
-    return callback;
-  },
-};
+if (global.ErrorUtils) {
+  module.exports = global.ErrorUtils;
+} else {
+  var ErrorUtils = {
+    applyWithGuard(callback, context, args, onError, name) {
+      return callback.apply(context, args);
+    },
+    guard(callback, name) {
+      return callback;
+    },
+  };
 
-module.exports = ErrorUtils;
+  module.exports = ErrorUtils;
+}


### PR DESCRIPTION
This PR performs the necessary changes to `fbjs` to allow for better compatibility with React Native, post the https://github.com/facebook/react-native/commit/6a838a4201f99ae5e88b3684bb798d363815dd53 commit.

TLDR; this PR does the following:

1. Strips the `@providesModule` directives from the built, npm version of fbjs (courtesy of @zpao). This is no longer necessary after https://github.com/facebook/react-native/pull/5084 is merged.
2. Switch to `isomorphic-fetch`, in order to avoid causing weird `require` issues that happen when the `whatwg-fetch` module is required on React Native (courtesy of @zpao). Also fixes the issues discussed in https://github.com/facebook/fbjs/pull/61, which is where this commit is from.
3. Adds the React Native promise implementation as `Promise.native.js`. The `.native` suffix was added in https://github.com/facebook/react-native/commit/6a838a4201f99ae5e88b3684bb798d363815dd53, and allows the RN packager to require a different file for a given module.
4. Checks for existence of `ErrorUtils` before setting the `fbjs` version on `global`. This is needed as `ErrorUtils` on React Native is polyfilled with specific behavior.

**Note:  # 3 is most likely a temporary fix. After discussing with @spicyj, the desired result would be to eventually remove the packager complexity introduced in https://github.com/facebook/react-native/commit/6a838a4201f99ae5e88b3684bb798d363815dd53. The reason I'm going for this approach at the moment is that it's only one module that needs this shimming in `fbjs`, and I think the value it brings, given the fact that this PR, along with the corresponding PR in react-native, allows for Relay to work OOTB, outweighs its small of amount of technical debt. It's very possible you all may disagree, and I'm happy to change the approach if we come up with a better solution. :)**