### PR TITLE
Update CHANGELOG.md for 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## [Unreleased]
 
+## [0.7.0] - 2016-01-04
+
+### Added
+
+- `Promise` with `finally` method for React Native
+
+### Changed
+
+- `ErrorUtils`: Re-uses any global instance that already exists
+- `getActiveElement`: Handles a non-existent `document` (again)
+
 ## [0.6.0] - 2015-12-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - `ErrorUtils`: Re-uses any global instance that already exists
+- `fetch`: Switched to `isomorphic-fetch` when a global implementation is missing
 - `getActiveElement`: Handles a non-existent `document` (again)
 
 ## [0.6.0] - 2015-12-29

--- a/scripts/CHANGELOG.md
+++ b/scripts/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## [Unreleased]
 
+## [0.7.0] - 2016-01-04
+
 ### Added
 - [babel] Added rewrite-modules plugin for Babel 6
+- [gulp] Added strip-provides-module to strip `@providesModule` headers
 
 
 ## [0.5.0] - 2015-11-11


### PR DESCRIPTION
This is just a placeholder with a list of changes since 0.6.0. We can update / replace it when 0.7.0 is actually published.

cc @zpao 