### PR TITLE
Strip @providesModule from flow.js files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,6 +68,7 @@ gulp.task('lib', function() {
 gulp.task('flow', function() {
   return gulp
     .src(paths.lib.src)
+    .pipe(gulpStripProvidesModule())
     .pipe(flatten())
     .pipe(rename({extname: '.js.flow'}))
     .pipe(gulp.dest(paths.lib.dest));


### PR DESCRIPTION
Strips @providesModule from flow.js files, as we're already stripping them from the built .js files.

/cc @spicyj @zpao