### PR TITLE
0.6.1 (NOT FOR MERGE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [0.6.1] - 2016-01-06
+
+### Changed
+- `getActiveElement`: no longer throws in non-browser environment (again)
+
 ## [0.6.0] - 2015-12-29
 
 ### Changed

--- a/src/core/dom/__tests__/getActiveElement-test.js
+++ b/src/core/dom/__tests__/getActiveElement-test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+jest.dontMock('getActiveElement');
+
+var getActiveElement = require('getActiveElement');
+
+describe('getActiveElement', () => {
+  it('returns body when there is no activeElement', () => {
+    var element = getActiveElement();
+    expect(element.tagName).toEqual('BODY');
+  });
+});

--- a/src/core/dom/getActiveElement.js
+++ b/src/core/dom/getActiveElement.js
@@ -10,13 +10,19 @@
  * @typechecks
  */
 
+/* eslint-disable fb-www/typeof-undefined */
+
 /**
  * Same as document.activeElement but wraps in a try-catch block. In IE it is
  * not safe to call document.activeElement if there is nothing focused.
  *
- * The activeElement will be null only if the document body is not yet defined.
+ * The activeElement will be null only if the document or document body is not
+ * yet defined.
  */
 function getActiveElement() /*?DOMElement*/ {
+  if (typeof document === 'undefined') {
+    return null;
+  }
   try {
     return document.activeElement || document.body;
   } catch (e) {


### PR DESCRIPTION
I'm going to actually make this a branch in the fb repo but putting it up as a PR just for a quick discussion.

The main issue here is that we need this in React ASAP (breaks some testing functionality). I could publish this as 0.6.1 and React from npm will pick it up no problem. But we need to publish a new browser version, so regardless, we need to ship a new version of React.

The other issue is that the version number is… perhaps not exactly semver. We probably should make this 0.7, but in order to avoid the cascading issue with upgrading React Native and other projects so everybody has the same version of fbjs, it's so much easier to just make it 0.6.1. It's sort of a bugfix since we didn't mean to revert the change…

cc @ide since we've talked about the semver issue. I think this is probably fine but wanted to get a second opinion before I went ahead.