### PR TITLE
Add support for promise rejection tracking in native Promise polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "core-js": "^1.0.0",
     "loose-envify": "^1.0.0",
     "isomorphic-fetch": "^2.1.1",
-    "promise": "^7.0.3",
+    "promise": "^7.1.1",
     "ua-parser-js": "^0.7.9"
   },
   "devEngines": {

--- a/src/__forks__/Promise.native.js
+++ b/src/__forks__/Promise.native.js
@@ -16,6 +16,27 @@
 var Promise = require('promise/setimmediate/es6-extensions');
 require('promise/setimmediate/done');
 
+if (__DEV__) {
+  require('promise/setimmediate/rejection-tracking').enable({
+    allRejections: true,
+    onUnhandled: (id, error) => {
+      const {message, stack} = error;
+      const warning =
+        `Possible Unhandled Promise Rejection (id: ${id}):\n` +
+        (message == null ? '' : `${message}\n`) +
+        (stack == null ? '' : stack);
+      console.warn(warning);
+    },
+    onHandled: (id) => {
+      const warning =
+        `Promise Rejection Handled (id: ${id})\n` +
+        'This means you can ignore any previous messages of the form ' +
+        `"Possible Unhandled Promise Rejection (id: ${id}):"`;
+      console.warn(warning);
+    },
+  });
+}
+
 /**
  * Handle either fulfillment or rejection with the same callback.
  */


### PR DESCRIPTION
This is to mimic and keep in sync the change from React Native on `Promise.js`.

Commit in question: https://github.com/facebook/react-native/commit/b0640946873945ee95d2cab8f549c915dbfffd70

Hopefully we won't have to do too many of these pending the fbjs changes in the RN packager.
