### PR TITLE
make shallowEqual use call instead of bind

### DIFF
--- a/src/core/shallowEqual.js
+++ b/src/core/shallowEqual.js
@@ -38,9 +38,8 @@ function shallowEqual(objA: mixed, objB: mixed): boolean {
   }
 
   // Test for A's keys different from B.
-  var bHasOwnProperty = hasOwnProperty.bind(objB);
   for (var i = 0; i < keysA.length; i++) {
-    if (!bHasOwnProperty(keysA[i]) || objA[keysA[i]] !== objB[keysA[i]]) {
+    if (!hasOwnProperty.call(objB, keysA[i]) || objA[keysA[i]] !== objB[keysA[i]]) {
       return false;
     }
   }


### PR DESCRIPTION
Forgive me if I'm overlooking something obvious, but there doesn't seem to be a good reason to use bind here. It's still really slow. Using .call is a lot faster and seems to have no negative tradeoffs. Given that this method gets used in react's shallowCompare utility, which in turn finds its way into people's shouldComponentUpdate methods, it really seems like there are good reasons to be persnickety about .bind's performance.

I'm including a test on [jsperf](http://jsperf.com/shallowequal-call-vs-bind) (yeah, I know. Sorry). That naïvely demonstrates a 4x perf improvement (on Chrome 47) with this simple change. 