### PR TITLE
Adding rejection-tracking promise module to module map

### DIFF
--- a/scripts/babel/default-options.js
+++ b/scripts/babel/default-options.js
@@ -47,6 +47,7 @@ module.exports = {
     'promise': 'promise',
     'promise/setimmediate/done': 'promise/setimmediate/done',
     'promise/setimmediate/es6-extensions': 'promise/setimmediate/es6-extensions',
+    'promise/setimmediate/rejection-tracking': 'promise/setimmediate/rejection-tracking',
     'ua-parser-js': 'ua-parser-js',
   },
 };


### PR DESCRIPTION
Not having this module listed in the default options breaks `Promise.native.js` on build, as it `requires('./promise/setimmediate/rejection-tracking')` rather than the proper module sans the `./`.

/cc @zpao @martinbigio 