### PR TITLE
Update URI stub to have most basic expected functionality: stringification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- `URI`: correctly store reference to value in constructor and return it when stringifying
+
 ## [0.7.1] - 2016-02-02
 
 ### Fixed

--- a/src/stubs/URI.js
+++ b/src/stubs/URI.js
@@ -7,12 +7,22 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule URI
- * @typechecks
+ * @stub
  * @flow
  */
 
 'use strict';
 
-class URI {}
+class URI {
+  _uri: string;
+
+  constructor(uri: string) {
+    this._uri = uri;
+  }
+
+  toString(): string {
+    return this._uri;
+  }
+}
 
 module.exports = URI;


### PR DESCRIPTION
Was working on a project using URI and hit the expectation that stringifying an instance would give a string uri back.