### PR TITLE
Move RN Promise rejection tracking code out of fbjs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Fixed
 - `URI`: correctly store reference to value in constructor and return it when stringifying
 
+### Removed
+- Backed out rejection tracking for React Native `Promise` implementation. That code now lives in React Native.
+
 ## [0.7.1] - 2016-02-02
 
 ### Fixed

--- a/scripts/babel/default-options.js
+++ b/scripts/babel/default-options.js
@@ -47,7 +47,6 @@ module.exports = {
     'promise': 'promise',
     'promise/setimmediate/done': 'promise/setimmediate/done',
     'promise/setimmediate/es6-extensions': 'promise/setimmediate/es6-extensions',
-    'promise/setimmediate/rejection-tracking': 'promise/setimmediate/rejection-tracking',
     'ua-parser-js': 'ua-parser-js',
   },
 };

--- a/src/__forks__/Promise.native.js
+++ b/src/__forks__/Promise.native.js
@@ -16,27 +16,6 @@
 var Promise = require('promise/setimmediate/es6-extensions');
 require('promise/setimmediate/done');
 
-if (__DEV__) {
-  require('promise/setimmediate/rejection-tracking').enable({
-    allRejections: true,
-    onUnhandled: (id, error) => {
-      const {message, stack} = error;
-      const warning =
-        `Possible Unhandled Promise Rejection (id: ${id}):\n` +
-        (message == null ? '' : `${message}\n`) +
-        (stack == null ? '' : stack);
-      console.warn(warning);
-    },
-    onHandled: (id) => {
-      const warning =
-        `Promise Rejection Handled (id: ${id})\n` +
-        'This means you can ignore any previous messages of the form ' +
-        `"Possible Unhandled Promise Rejection (id: ${id}):"`;
-      console.warn(warning);
-    },
-  });
-}
-
 /**
  * Handle either fulfillment or rejection with the same callback.
  */


### PR DESCRIPTION
After discussion with @davidaurelio, this PR moves the Promise rejection tracking code out of fbjs (really shouldn't have been in there in the first place), and instead just makes fbjs export a React Native compliant version of Promise, rather than adding functionality.

The corresponding change in RN will require the release of 0.7.2 of fbjs.