### PR TITLE
Update babel-eslint to fix eslint in CI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "babel": "^5.4.7",
-    "babel-eslint": "4.1.5",
+    "babel-eslint": "4.1.8",
     "del": "^1.2.1",
     "eslint": "1.10.3",
     "fbjs-scripts": "file:scripts",


### PR DESCRIPTION
`babel-eslint@4.1.5` was broken with the version of Babel that's used on this package. This updates babel-eslint to the latest 4.x point release, which fixes the `visitClass` error that you see in CI.