### PR TITLE
[scripts] Check that all lib files can be required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "4"
 env:
+  - CMD=build
   - CMD=test
   - CMD=typecheck
   - CMD=lint

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "facebook/fbjs",
   "scripts": {
     "build": "gulp build",
+    "postbuild": "node scripts/node/check-lib-requires.js lib",
     "lint": "eslint .",
     "prepublish": "npm run build",
     "pretest": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",

--- a/scripts/CHANGELOG.md
+++ b/scripts/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [babel] Added rewrite-modules plugin for Babel 6
 - [gulp] Added strip-provides-module to strip `@providesModule` headers
 - [gulp] Added check-dependencies to ensure installed packages are compatible with package.json specification
+- [node] Added check-lib-requires script to ensure all lib files can be required
 
 
 ## [0.5.0] - 2015-11-11

--- a/scripts/node/check-lib-requires.js
+++ b/scripts/node/check-lib-requires.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const EXTRACT_MODULE_NAME_REGEX = /'\.\/(.+)'/;
+
+let didError = false;
+
+// Make sure we have a lib to read files from. Take it as the first argument.
+assert(
+  process.argv.length >= 3,
+  'Expected to receive an argument to a lib directory'
+);
+
+const pathToLib = path.resolve(process.cwd(), process.argv[2]);
+
+fs.readdir(pathToLib, (err, files) => {
+  files = files.filter((filename) => path.parse(filename).ext === '.js');
+
+  files.forEach((filename) => {
+    const requirePath = path.join(pathToLib, filename);
+    const moduleName = path.parse(filename).name;
+
+    try {
+      require(requirePath);
+    } catch (e) {
+      if (e.code === 'MODULE_NOT_FOUND') {
+        const missingModule = e.toString().match(EXTRACT_MODULE_NAME_REGEX)[1];
+        console.error(moduleName, 'is missing a dependency:', missingModule);
+      }
+      didError = true;
+    }
+  });
+
+  process.exit(didError ? 1 : 0);
+});


### PR DESCRIPTION
Quick and dirty but it works. It turns out I missed a dependency while working on #113 so this will now prevent the build from completing successfully. It's written so that any of our other projects should be able to use it too.

Fixes #68 