### PR TITLE
[babel] Rewrite more jest methods

### DIFF
--- a/scripts/CHANGELOG.md
+++ b/scripts/CHANGELOG.md
@@ -5,6 +5,9 @@
 - [gulp] Added strip-provides-module to strip `@providesModule` headers
 - [gulp] Added check-dependencies to ensure installed packages are compatible with package.json specification
 
+### Fixed
+- [babel] Fixed the rewrite-modules plugin to support more Jest methods
+
 
 ## [0.5.0] - 2015-11-11
 - [babel] Add auto-importer plugin for Babel & Babel 6

--- a/scripts/babel-6/__tests__/rewrite-modules-test.js
+++ b/scripts/babel-6/__tests__/rewrite-modules-test.js
@@ -32,13 +32,15 @@ describe('rewrite-modules', function() {
         expect(result.code).toEqual('require(\'test/test\');');
       });
 
-      it('should work for jest. mock, dontMock and genMockFromModule', function() {
+      it('should transform jest and requireActual methods', function() {
         const code = `function test() {
           'use strict';
 
           jest.mock('foo');
           jest.mock('foo').mock('bar').dontMock('baz');
           var fooMock = jest.genMockFromModule('foo');
+          jest.unmock('foo');
+          jest.setMock('foo', () => {});
 
           var foo = require('foo');
           var actualFoo = require.requireActual('foo');
@@ -50,6 +52,8 @@ describe('rewrite-modules', function() {
           jest.mock('foo/foo');
           jest.mock('foo/foo').mock('bar/bar').dontMock('baz/baz');
           var fooMock = jest.genMockFromModule('foo/foo');
+          jest.unmock('foo/foo');
+          jest.setMock('foo/foo', () => {});
 
           var foo = require('foo/foo');
           var actualFoo = require.requireActual('foo/foo');


### PR DESCRIPTION
Also slipped in a related-ish change, to preserve all arguments when
rewriting the first. This was required to support the `jest.setMock`
use.