### PR TITLE
Relativize requires in .flow.js files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,11 +6,13 @@ var del = require('del');
 var mergeStream = require('merge-stream');
 var runSequence = require('run-sequence');
 
-var babelPluginDEV = require('fbjs-scripts/babel-6/dev-expression');
 var babelDefaultOptions = require('fbjs-scripts/babel-6/default-options');
+var babelPluginDEV = require('fbjs-scripts/babel-6/dev-expression');
+var babelPluginModules = require('fbjs-scripts/babel-6/rewrite-modules');
 var gulpModuleMap = require('fbjs-scripts/gulp/module-map');
 var gulpStripProvidesModule = require('fbjs-scripts/gulp/strip-provides-module');
 var gulpCheckDependencies = require('fbjs-scripts/gulp/check-dependencies');
+var thirdPartyModuleMap = require('fbjs-scripts/third-party-module-map.json');
 
 var paths = {
   lib: {
@@ -67,6 +69,15 @@ gulp.task('lib', function() {
 gulp.task('flow', function() {
   return gulp
     .src(paths.lib.src)
+    .pipe(gulpModuleMap(moduleMapOpts))
+    .pipe(babel({
+      plugins: [
+        "syntax-flow",
+        "syntax-trailing-function-commas",
+        "syntax-object-rest-spread",
+        [babelPluginModules, {map: thirdPartyModuleMap}]
+      ]
+    }))
     .pipe(flatten())
     .pipe(rename({extname: '.js.flow'}))
     .pipe(gulp.dest(paths.lib.dest));

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "babel-eslint": "^5.0.0",
     "babel-plugin-check-es2015-constants": "^6.5.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.5.0",
+    "babel-plugin-syntax-object-rest-spread": "^6.3.13",
     "babel-plugin-transform-class-properties": "^6.5.0",
     "babel-plugin-transform-es2015-arrow-functions": "^6.5.2",
     "babel-plugin-transform-es2015-block-scoped-functions": "^6.5.0",
@@ -85,9 +86,10 @@
     ]
   },
   "dependencies": {
+    "babel-plugin-syntax-flow": "^6.5.0",
     "core-js": "^1.0.0",
-    "loose-envify": "^1.0.0",
     "isomorphic-fetch": "^2.1.1",
+    "loose-envify": "^1.0.0",
     "promise": "^7.1.1",
     "ua-parser-js": "^0.7.9"
   },

--- a/scripts/babel-6/default-options.js
+++ b/scripts/babel-6/default-options.js
@@ -13,6 +13,7 @@ var assign = require('object-assign');
 var babelPluginModules = require('./rewrite-modules');
 var babelPluginAutoImporter = require('./auto-importer');
 var inlineRequires = require('./inline-requires');
+var thirdPartyModuleMap = require('../third-party-module-map.json');
 
 function plugins(moduleOpts) {
   var plugins = [
@@ -38,17 +39,7 @@ function plugins(moduleOpts) {
     "transform-es3-property-literals",
     "transform-object-rest-spread",
     babelPluginAutoImporter,
-    [babelPluginModules, assign({
-      map: {
-        'core-js/library/es6/map': 'core-js/library/es6/map',
-        'core-js/library/es6/set': 'core-js/library/es6/set',
-        'isomorphic-fetch': 'isomorphic-fetch',
-        'promise': 'promise',
-        'promise/setimmediate/done': 'promise/setimmediate/done',
-        'promise/setimmediate/es6-extensions': 'promise/setimmediate/es6-extensions',
-        'ua-parser-js': 'ua-parser-js',
-      },
-    }, moduleOpts)],
+    [babelPluginModules, assign({map: thirdPartyModuleMap}, moduleOpts)],
   ];
 
   if (process.env.NODE_ENV === 'test') {

--- a/scripts/third-party-module-map.json
+++ b/scripts/third-party-module-map.json
@@ -1,0 +1,9 @@
+{
+  "core-js/library/es6/map": "core-js/library/es6/map",
+  "core-js/library/es6/set": "core-js/library/es6/set",
+  "isomorphic-fetch": "isomorphic-fetch",
+  "promise": "promise",
+  "promise/setimmediate/done": "promise/setimmediate/done",
+  "promise/setimmediate/es6-extensions": "promise/setimmediate/es6-extensions",
+  "ua-parser-js": "ua-parser-js"
+}

--- a/src/functional/compactArray.js
+++ b/src/functional/compactArray.js
@@ -14,7 +14,7 @@
  * `Array.prototype.filter`.
  */
 function compactArray<T>(
-  array: Array<?T>
+  array: Array<T|null|void>
 ): Array<T> {
   var result = [];
   for (var i = 0; i < array.length; ++i) {


### PR DESCRIPTION
Now that we are on Babel 6, it's easy to pull in only the transforms that we need, leaving the rest intact.

Fixes #118

Test Plan:
Took the diff of the current master's `lib` and this PR's. It's pretty noisy, but you can see that the local requires are relative and node_module requires remain absolute. https://gist.github.com/samwgoldman/028cf76abf1e072920c5