### PR TITLE
Create a fork of `Map` just for React Native.

### DIFF
--- a/src/__forks__/Map.native.js
+++ b/src/__forks__/Map.native.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+module.exports = require('Map');


### PR DESCRIPTION
This should let us eliminate `Map` from the React Native packager's blacklist.
