### PR TITLE
Bump devEngine requirement to node >=4

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "ua-parser-js": "^0.7.9"
   },
   "devEngines": {
-    "node": ">=3",
+    "node": ">=4",
     "npm": ">=2.x"
   },
   "browserify": {


### PR DESCRIPTION
Closes #128.

After this, we can start going crazy with all the ES2015 features.