### PR TITLE
Fixes broken scrollTop position

### DIFF
--- a/src/core/dom/getScrollPosition.js
+++ b/src/core/dom/getScrollPosition.js
@@ -36,7 +36,7 @@ function getScrollPosition(scrollable) {
 
   const viewport =
     scrollable === documentScrollElement ?
-      document.documentElement :
+      document.body :
       scrollable;
 
   const xMax = scrollable.scrollWidth - viewport.clientWidth;


### PR DESCRIPTION
Else the `scrollable.scrollHeight` will always be the same as the `viewport.clientHeight` which causes the max scroll Y position to always be `0` (the top of the page).
