### PR TITLE
Add old Promise Flow definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
-lib
+lib/*
 module-map.json
-flow/include

--- a/flow/lib/Promise.js
+++ b/flow/lib/Promise.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+// These annotations are copy/pasted from the built-in Flow definitions for
+// Native Promises with some non-standard APIs added in
+declare class Promise<+R> {
+  constructor(callback: (
+    resolve: (result?: Promise<R> | R) => void,
+    reject: (error?: any) => void
+  ) => mixed): void;
+
+  then<U>(
+    onFulfill?: ?(value: R) => Promise<U> | ?U,
+    onReject?: ?(error: any) => Promise<U> | ?U
+  ): Promise<U>;
+
+  catch<U>(
+    onReject?: (error: any) => ?Promise<U> | U
+  ): Promise<U>;
+
+  static resolve<T>(object?: Promise<T> | T): Promise<T>;
+  static reject<T>(error?: any): Promise<T>;
+
+  static all: Promise$All;
+  static race<T>(promises: Array<Promise<T>>): Promise<T>;
+
+  // Non-standard APIs
+  done<U>(
+    onFulfill?: ?(value: R) => mixed,
+    onReject?: ?(error: any) => mixed
+  ): void;
+
+  static cast<T>(object?: T): Promise<T>;
+}


### PR DESCRIPTION
Flow 0.23 removed the un-speced methods from the Promise class, which is
the right thing to do. However our Promise impl does have those methods
and we use them so for now, the best thing to do is just ship the
Promise class definition that we are using. In the future we can stop
relying on that method.

Also fixed gitignore to pick up changes in `flow/lib` properly.