### PR TITLE
Relativize type import in .flow.js files

### DIFF
--- a/babel-preset/plugins/__tests__/rewrite-modules-test.js
+++ b/babel-preset/plugins/__tests__/rewrite-modules-test.js
@@ -33,6 +33,20 @@ describe('rewrite-modules', function() {
         expect(result.code).toEqual('require(\'test/test\');');
       });
 
+      it('should replace the prefix on type imports', function() {
+        let result = babel.transform(
+          'import type Test from "test";',
+          {
+            plugins: [
+              'syntax-flow',
+              [rewriteModules, {map: {'test': 'test/test'}}]
+            ],
+          }
+        );
+
+        expect(result.code).toEqual('import type Test from "test/test";');
+      });
+
       it('should transform jest and requireActual methods', function() {
         const code = `function test() {
           'use strict';

--- a/babel-preset/plugins/rewrite-modules.js
+++ b/babel-preset/plugins/rewrite-modules.js
@@ -76,6 +76,19 @@ module.exports = function(babel) {
   }
 
   /**
+   * Transforms `import type Bar from 'foo'`
+   */
+  function transformTypeImport(path, state) {
+    var source = path.get('source');
+    if (source.type === 'StringLiteral') {
+      var module = mapModule(state, source.node.value);
+      if (module) {
+        source.replaceWith(t.stringLiteral(module));
+      }
+    }
+  }
+
+  /**
    * Transforms either individual or chained calls to `jest.dontMock('Foo')`,
    * `jest.mock('Foo')`, and `jest.genMockFromModule('Foo')`.
    */
@@ -126,6 +139,14 @@ module.exports = function(babel) {
           path.node.seen = true;
         },
       },
+      ImportDeclaration: {
+        exit(path, state) {
+          if (path.node.importKind !== 'type') {
+            return;
+          }
+          transformTypeImport(path, state);
+        }
+      }
     },
   };
 };


### PR DESCRIPTION
Generate relative type imports in .js.flow files

This is the diff of the current master's lib and this PR's:
https://gist.github.com/tsing/afa63600f4aa41c729f3eb2017c862eb