### PR TITLE
Remove "Failed Composite propType" checking from `warning`

### DIFF
--- a/src/__forks__/warning.js
+++ b/src/__forks__/warning.js
@@ -31,10 +31,6 @@ if (__DEV__) {
       );
     }
 
-    if (format.indexOf('Failed Composite propType: ') === 0) {
-      return; // Ignore CompositeComponent proptype check.
-    }
-
     if (!condition) {
       var argIndex = 0;
       var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);


### PR DESCRIPTION
Fixes #152. facebook/react#6824 removed duplicate propType checking, therefore the blacklist at https://github.com/facebook/fbjs/blob/master/src/__forks__/warning.js#L34-L36 is no longer necessary. 