### PR TITLE
invariant: more strict check for format argument

### DIFF
--- a/src/__forks__/invariant.js
+++ b/src/__forks__/invariant.js
@@ -31,7 +31,7 @@ function invariant(condition, format, a, b, c, d, e, f) {
 
   if (!condition) {
     var error;
-    if (format === undefined) {
+    if (typeof format !== 'string') {
       error = new Error(
         'Minified exception occurred; use the non-minified dev environment ' +
         'for the full error message and additional helpful warnings.'


### PR DESCRIPTION
The `format` argument actually must be a native `String` object, because it requires to own the `.replace` function, such that I improve the type check here might be better :-)