### PR TITLE
[fbjs-css-vars] Initial release

### DIFF
--- a/packages/fbjs-css-vars/CHANGELOG.md
+++ b/packages/fbjs-css-vars/CHANGELOG.md
@@ -1,0 +1,4 @@
+## [1.0.0] - 2016-07-14
+
+### Added
+- Initial release with variables used by Fixed Data Table and Draft.

--- a/packages/fbjs-css-vars/LICENSE
+++ b/packages/fbjs-css-vars/LICENSE
@@ -1,0 +1,31 @@
+BSD License
+
+For fbjs-css-vars software
+
+Copyright (c) 2013-present, Facebook, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/fbjs-css-vars/PATENTS
+++ b/packages/fbjs-css-vars/PATENTS
@@ -1,0 +1,33 @@
+Additional Grant of Patent Rights Version 2
+
+"Software" means the fbjs-css-vars software distributed by Facebook, Inc.
+
+Facebook, Inc. ("Facebook") hereby grants to each recipient of the Software
+("you") a perpetual, worldwide, royalty-free, non-exclusive, irrevocable
+(subject to the termination provision below) license under any Necessary
+Claims, to make, have made, use, sell, offer to sell, import, and otherwise
+transfer the Software. For avoidance of doubt, no license is granted under
+Facebook's rights in any patent claims that are infringed by (i) modifications
+to the Software made by you or any third party or (ii) the Software in
+combination with any software or other technology.
+
+The license granted hereunder will terminate, automatically and without notice,
+if you (or any of your subsidiaries, corporate affiliates or agents) initiate
+directly or indirectly, or take a direct financial interest in, any Patent
+Assertion: (i) against Facebook or any of its subsidiaries or corporate
+affiliates, (ii) against any party if such Patent Assertion arises in whole or
+in part from any software, technology, product or service of Facebook or any of
+its subsidiaries or corporate affiliates, or (iii) against any party relating
+to the Software. Notwithstanding the foregoing, if Facebook or any of its
+subsidiaries or corporate affiliates files a lawsuit alleging patent
+infringement against you in the first instance, and you respond by filing a
+patent infringement counterclaim in that lawsuit against that party that is
+unrelated to the Software, the license granted hereunder will not terminate
+under section (i) of this paragraph due to such counterclaim.
+
+A "Necessary Claim" is a claim of a patent owned by Facebook that is
+necessarily infringed by the Software standing alone.
+
+A "Patent Assertion" is any lawsuit or other action alleging direct, indirect,
+or contributory infringement or inducement to infringe any patent, including a
+cross-claim or counterclaim.

--- a/packages/fbjs-css-vars/README.md
+++ b/packages/fbjs-css-vars/README.md
@@ -1,0 +1,38 @@
+# fbjs-css-vars
+
+This package exports a few of the CSS variables that we use in Facebook projects. This is not the full list we have internally but focused on making available the minimum set needed by our open source projects.
+
+## Usage
+
+There are almost no use cases where a product will use this module. It will primarily be consumed by one of the following:
+
+### `cssVar`
+
+This is a module that will read from the list we have here and return the corresponding value. Internally we transform this statically but we don't currently do that in our open source projects.
+
+```js
+React.render(
+  <div style={{backgroundColor: cssVar('fbui-white')}} />,
+  containerNode
+);
+```
+
+### CSS
+
+In order to directly sync out our internal CSS and have it parsed by browser, we need to apply some transforms like we do internally. One of those transforms will insert the variables we have available here. In the future we may make use of [CSS Variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables).
+
+```css
+.class {
+  background-color: var(fbui-white);
+}
+```
+
+### Direct Usage
+
+We're just exporting a JS Object so usage is straightforward.
+
+```js
+var fbCSSVars = require('fbjs-css-vars')
+
+console.log(fbCSSVars['fbui-white']);
+```

--- a/packages/fbjs-css-vars/index.js
+++ b/packages/fbjs-css-vars/index.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+module.exports = {
+  'fbui-desktop-background-light': '#f6f7f8',
+  'fbui-desktop-text-placeholder': '#9197a3',
+  'fbui-desktop-text-placeholder-focused': '#bdc1c9',
+  'fbui-white': '#fff',
+  'scrollbar-face-active-color': '#7d7d7d',
+  'scrollbar-face-color': '#c2c2c2',
+  'scrollbar-face-margin': '4px',
+  'scrollbar-face-radius': '6px',
+  'scrollbar-size': '15px',
+  'scrollbar-size-large': '17px',
+  'scrollbar-track-color': 'rgba(255, 255, 255, 0.8)',
+};

--- a/packages/fbjs-css-vars/package.json
+++ b/packages/fbjs-css-vars/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fbjs-css-vars",
+  "version": "1.0.0",
+  "description": "This package exports a few of the CSS variables that we use in Facebook projects. This is not the full list we have internally but focused on making available the minimum set needed by our open source projects.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "BSD-3-Clause"
+}


### PR DESCRIPTION
This is motivated by the revival of fixed-data-table which uses our `cssVar` module and has variables in CSS. Draft also has some of these variables in its CSS. We do a simple replace in Draft's build process, which we can also do in FDT but to ensure our list stays up to date we want these in a shared place. I didn't just make a shared CSS transform since we also need these values to appear in JS. In the future we can write a Babel transform that replaces `cssVar` calls but the lowest friction thing is to just make this module a dependency of `fbjs` and read from it there.