### PR TITLE
Extract try/catch into a separate function to prevent deopt

### DIFF
--- a/packages/fbjs/src/__forks__/warning.js
+++ b/packages/fbjs/src/__forks__/warning.js
@@ -23,6 +23,20 @@ var emptyFunction = require('emptyFunction');
 var warning = emptyFunction;
 
 if (__DEV__) {
+  function printWarning(format, ...args) {
+    var argIndex = 0;
+    var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
+    if (typeof console !== 'undefined') {
+      console.error(message);
+    }
+    try {
+      // --- Welcome to debugging React ---
+      // This error was thrown as a convenience so that you can use this stack
+      // to find the callsite that caused this warning to fire.
+      throw new Error(message);
+    } catch (x) {}
+  }
+
   warning = function(condition, format, ...args) {
     if (format === undefined) {
       throw new Error(
@@ -30,19 +44,8 @@ if (__DEV__) {
         'message argument'
       );
     }
-
     if (!condition) {
-      var argIndex = 0;
-      var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
-      if (typeof console !== 'undefined') {
-        console.error(message);
-      }
-      try {
-        // --- Welcome to debugging React ---
-        // This error was thrown as a convenience so that you can use this stack
-        // to find the callsite that caused this warning to fire.
-        throw new Error(message);
-      } catch (x) {}
+      printWarning(format, ...args);
     }
   };
 }


### PR DESCRIPTION
Not a big deal but this can add up if a lot of elements are being created (such as the case with FixedDataTable).

Before:

<img width="497" alt="screen shot 2016-08-17 at 17 33 22" src="https://cloud.githubusercontent.com/assets/810438/17744762/086ca89a-64a1-11e6-8820-a9537356f3f1.png">

After:

<img width="493" alt="screen shot 2016-08-17 at 17 32 40" src="https://cloud.githubusercontent.com/assets/810438/17744765/0cee32bc-64a1-11e6-83d6-9e685dbaaa9f.png">
