### PR TITLE
[eslint-config-fbjs] Create a "strict" config

### DIFF
--- a/packages/eslint-config-fbjs/CHANGELOG.md
+++ b/packages/eslint-config-fbjs/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Added
+- `fbjs/strict` config, with the same rules enabled as the default config, with each warning upgraded to an error.
+
 ### Changed
 - Switched to use eslint-plugin-flowtype for Flow-related rules
 

--- a/packages/eslint-config-fbjs/package.json
+++ b/packages/eslint-config-fbjs/package.json
@@ -10,7 +10,8 @@
     "LICENSE",
     "PATENTS",
     "README.md",
-    "index.js"
+    "index.js",
+    "strict.js"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/eslint-config-fbjs/strict.js
+++ b/packages/eslint-config-fbjs/strict.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+let config = JSON.parse(JSON.stringify(require('.')));
+
+Object.keys(config.rules).forEach((rule) => {
+  let val = config.rules[rule];
+  if (Array.isArray(val)) {
+    if (val[0] === 0) {
+      return;
+    }
+    val[0] = 2;
+    config.rules[rule] = val;
+    return;
+  }
+  if (val === 0) {
+    return;
+  }
+  config.rules[rule] = 2;
+});
+
+module.exports = config;


### PR DESCRIPTION
This is the default config, with all rules that were warnings upgraded to errors.

We've wanted a stricter version of the config so that warnings don't slip past travis. So this is that.