### PR TITLE
Document how to use the caught exception.

### DIFF
--- a/packages/fbjs/src/__forks__/warning.js
+++ b/packages/fbjs/src/__forks__/warning.js
@@ -33,6 +33,9 @@ if (__DEV__) {
       // --- Welcome to debugging React ---
       // This error was thrown as a convenience so that you can use this stack
       // to find the callsite that caused this warning to fire.
+      //
+      // To use this, you can set a breakpoint on the following line,
+      // or configure your browser to 'break on caught exceptions'.
       throw new Error(message);
     } catch (x) {}
   }


### PR DESCRIPTION
It turns out that browsers can help you view a backtrace from a caught
exception, but this only seems to be documented in this GitHub thread
https://github.com/facebook/react/issues/4216#issuecomment-115053221

Add instructions for the different ways users can take advantage of us
throwing an error.