### PR TITLE
[fbjs] Restore flow/lib/dev.js

### DIFF
--- a/packages/fbjs/flow/lib/dev.js
+++ b/packages/fbjs/flow/lib/dev.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+declare var __DEV__: boolean;


### PR DESCRIPTION
This is primarily for direct consumers who want to use `__DEV__` in
their code and run flow on that code before the `__DEV__` transform is
run.


cf #185