### PR TITLE
Make DOM utilities work in nested browsing contexts

### DIFF
--- a/packages/fbjs/src/__forks__/Style.js
+++ b/packages/fbjs/src/__forks__/Style.js
@@ -48,7 +48,8 @@ var Style = {
     if (!node) {
       return null;
     }
-    while (node && node !== document.body) {
+    var ownerDocument = node.ownerDocument;
+    while (node && node !== ownerDocument.body) {
       if (_isNodeScrollable(node, 'overflow') ||
           _isNodeScrollable(node, 'overflowY') ||
           _isNodeScrollable(node, 'overflowX')) {
@@ -56,7 +57,7 @@ var Style = {
       }
       node = node.parentNode;
     }
-    return window;
+    return ownerDocument.defaultView || ownerDocument.parentWindow;
   },
 
 };

--- a/packages/fbjs/src/__forks__/getUnboundedScrollPosition.js
+++ b/packages/fbjs/src/__forks__/getUnboundedScrollPosition.js
@@ -23,10 +23,10 @@
  * @return {object} Map with `x` and `y` keys.
  */
 function getUnboundedScrollPosition(scrollable) {
-  if (scrollable === window) {
+  if (scrollable.Window && scrollable instanceof scrollable.Window) {
     return {
-      x: window.pageXOffset || document.documentElement.scrollLeft,
-      y: window.pageYOffset || document.documentElement.scrollTop
+      x: scrollable.pageXOffset || scrollable.document.documentElement.scrollLeft,
+      y: scrollable.pageYOffset || scrollable.document.documentElement.scrollTop
     };
   }
   return {

--- a/packages/fbjs/src/core/dom/__tests__/getActiveElement-test.js
+++ b/packages/fbjs/src/core/dom/__tests__/getActiveElement-test.js
@@ -19,4 +19,17 @@ describe('getActiveElement', () => {
     var element = getActiveElement();
     expect(element.tagName).toEqual('BODY');
   });
+
+  it('uses optional document parameter when provided', () => {
+    var iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    var iframeDocument = iframe.contentDocument;
+    var element = getActiveElement(iframeDocument);
+    try {
+      expect(element.ownerDocument).toBe(iframeDocument);
+      expect(element.ownerDocument).not.toBe(document);
+    } finally {
+      document.body.removeChild(iframe);
+    }
+  });
 });

--- a/packages/fbjs/src/core/dom/getActiveElement.js
+++ b/packages/fbjs/src/core/dom/getActiveElement.js
@@ -18,15 +18,19 @@
  *
  * The activeElement will be null only if the document or document body is not
  * yet defined.
+ *
+ * @param {?DOMDocument} doc Defaults to current document.
+ * @return {?DOMElement}
  */
-function getActiveElement() /*?DOMElement*/ {
-  if (typeof document === 'undefined') {
+function getActiveElement(doc) /*?DOMElement*/ {
+  doc = doc || document;
+  if (typeof doc === 'undefined') {
     return null;
   }
   try {
-    return document.activeElement || document.body;
+    return doc.activeElement || doc.body;
   } catch (e) {
-    return document.body;
+    return doc.body;
   }
 }
 

--- a/packages/fbjs/src/core/dom/getElementRect.js
+++ b/packages/fbjs/src/core/dom/getElementRect.js
@@ -19,7 +19,7 @@ const containsNode = require('containsNode');
  * @return {object}
  */
 function getElementRect(elem) {
-  const docElem = document.documentElement;
+  const docElem = elem.ownerDocument.documentElement;
 
   // FF 2, Safari 3 and Opera 9.5- do not support getBoundingClientRect().
   // IE9- will throw if the element is not in the document.

--- a/packages/fbjs/src/core/dom/getScrollPosition.js
+++ b/packages/fbjs/src/core/dom/getScrollPosition.js
@@ -28,15 +28,15 @@ const getUnboundedScrollPosition = require('getUnboundedScrollPosition');
  * @return {object} Map with `x` and `y` keys.
  */
 function getScrollPosition(scrollable) {
-  const documentScrollElement = getDocumentScrollElement();
-  if (scrollable === window) {
+  const documentScrollElement = getDocumentScrollElement(scrollable.ownerDocument || scrollable.document);
+  if (scrollable.Window && scrollable instanceof scrollable.Window) {
     scrollable = documentScrollElement;
   }
   const scrollPosition = getUnboundedScrollPosition(scrollable);
 
   const viewport =
     scrollable === documentScrollElement ?
-      document.documentElement :
+      scrollable.ownerDocument.documentElement :
       scrollable;
 
   const xMax = scrollable.scrollWidth - viewport.clientWidth;

--- a/packages/fbjs/src/core/dom/isNode.js
+++ b/packages/fbjs/src/core/dom/isNode.js
@@ -15,8 +15,10 @@
  * @return {boolean} Whether or not the object is a DOM node.
  */
 function isNode(object) {
+  var doc = object ? (object.ownerDocument || object) : document;
+  var defaultView = doc.defaultView || window;
   return !!(object && (
-    typeof Node === 'function' ? object instanceof Node :
+    typeof defaultView.Node === 'function' ? object instanceof defaultView.Node :
       typeof object === 'object' &&
       typeof object.nodeType === 'number' &&
       typeof object.nodeName === 'string'


### PR DESCRIPTION
Fixes #156. In the discussion in that issue, @spicyj wrote:

> If this is causing a problem in some Facebook project using fbjs, feel free to send a pull request.

I’ve seen a couple issues that I’m hoping can qualify, including:

facebook/react#427
facebook/draft-js#527

I can also say that I am working with a team on an editor app that would benefit greatly from having React, Draft.js, and fbjs all work seamlessly across iframes. When building a sophisticated editor of some kind, the use case of rendering from a single parent browsing context into a separate nested browsing context, treating it as a sandboxed rendering target that can publish UI events, is a really compelling one.

About the PR: We used eslint’s `no-undef` rule with a config that didn’t include the browser env to get a list of all files that use browser globals directly. We then went through each instance and adapted them to support use across nested browsing contexts where necessary.

Here’s a list of the files that use browser globals that we didn’t modify, along with an explanation of why. The only file we didn’t change where it could actually matter is `getViewportDimensions`, so I’ll start with that one:

`fbjs/src/core/dom/getViewportDimensions.js`

Uses global `document` and `window` extensively. Could be easily refactored to take an optional document argument, like `getDocumentScrollElement`, but I also couldn’t find it being used anywhere in fbjs or in React, so didn’t know if it was worth it or desired. Please let me know if I should implement that change.

`fbjs/src/__forks__/isEventSupported.js`
`fbjs/src/core/ExecutionEnvironment.js`
`fbjs/src/dom/translateDOMPositionXY.js`

Feature (or UA) detection against the global `window` / `document` objects

`fbjs/src/core/createNodesFromMarkup.js`
`fbjs/src/core/getMarkupWrap.js`
`fbjs/src/core/getVendorPrefixedName.js`

Uses `document.createElement()`, no nested browsing context issues

`fbjs/src/core/dom/getDocumentScrollElement.js`

Uses global `document` as fallback default (just like the changes we made in this PR for `getActiveElement.js`)

`fbjs/src/core/dom/getStyleProperty.js`

  Uses `window.getComputedStyle`, which seems to work fine across nested browsing contexts


There are also some polyfill / feature detections for fetch, requestAnimationFrame, Performance, ES2015 Map/Set that use globals, but I figured it wouldn’t be helpful to list those out.
