### PR TITLE
[babel-preset-fbjs] Add __DEV__ flow declaration when used

### DIFF
--- a/packages/babel-preset-fbjs/CHANGELOG.md
+++ b/packages/babel-preset-fbjs/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Added
+- Modules using `__DEV__` will have the declaration inlined for `.js.flow` file generation.
+
 ### Fixed
 - `typeof` imports are properly rewritten.
 

--- a/packages/babel-preset-fbjs/configure.js
+++ b/packages/babel-preset-fbjs/configure.js
@@ -48,6 +48,12 @@ module.exports = function(options) {
     ]
   ];
 
+  // We only want to add declarations for flow transforms and not for js. So we
+  // have to do this separate from above.
+  if (options.target === 'flow') {
+    presetSets[0].push(require('./plugins/dev-declaration'));
+  }
+
   // Enable everything else for js.
   if (options.target === 'js') {
     presetSets[0] = presetSets[0].concat([

--- a/packages/babel-preset-fbjs/plugins/__tests__/dev-declaration-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/dev-declaration-test.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+/* eslint-disable max-len */
+
+let babel = require('babel-core');
+let devDeclaration = require('../dev-declaration');
+
+function transform(input) {
+  return babel.transform(input, {
+    plugins: ['syntax-flow', devDeclaration],
+  }).code;
+}
+
+function compare(input, output) {
+  var compiled = transform(input);
+  expect(compiled).toEqual(output);
+}
+
+describe('dev-declaration', function() {
+
+  // Babel currently compiles booleanTypeAnnotation to `bool`. Will be `boolean`
+  // in the future.
+  it('should replace calls', () => {
+    compare(
+`if (__DEV__) console.log();`,
+`declare var __DEV__: bool;
+if (__DEV__) console.log();`);
+  });
+
+});

--- a/packages/babel-preset-fbjs/plugins/dev-declaration.js
+++ b/packages/babel-preset-fbjs/plugins/dev-declaration.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = function(babel) {
+  const t = babel.types;
+
+  // We can't construct an identifier with a type annotation all in 1 fell swoop
+  // so we have to create & mutate, then pass along.
+  const DEV_IDENTIFIER = t.identifier('__DEV__');
+  DEV_IDENTIFIER.typeAnnotation = t.typeAnnotation(t.booleanTypeAnnotation());
+  const DEV_DECLARATION = t.declareVariable(
+    DEV_IDENTIFIER
+  );
+
+  return {
+    pre() {
+      this.usesDEV = false;
+    },
+
+    visitor: {
+      Identifier: {
+        enter(path, file) {
+          this.usesDEV = this.usesDEV || path.isIdentifier({name: '__DEV__'});
+        },
+      },
+
+      Program: {
+        exit(path, file) {
+          if (!this.usesDEV) {
+            return;
+          }
+
+          // Add the declaration at the front of the body if we've used __DEV__.
+          path.node.body.unshift(DEV_DECLARATION);
+        },
+      },
+    },
+  };
+};


### PR DESCRIPTION
This allows us to continue using `__DEV__` in our code without having
a separate include that must be used anytime that `fbjs` (or other
projects using the same pattern) is used.

This is the diff after building fbjs on master: https://gist.github.com/zpao/8694c44a2aa1d52382059099d1006833

cf #185.

cc @gabelevi. This is what I was talking about. I *think* it makes sense but would love the Flow insider opinion now that it's real. I don't love that this seems to be the only way to do this right now.