### PR TITLE
Handle network errors / make it possible to alter request on error

### DIFF
--- a/packages/fbjs/src/fetch/fetchWithRetries.js
+++ b/packages/fbjs/src/fetch/fetchWithRetries.js
@@ -28,6 +28,7 @@ export type InitWithRetries = {
   method?: ?string,
   mode?: ?string,
   retryDelays?: ?Array<number>,
+  onError?(error: any, initConfig: any): ?boolean,
 };
 
 const DEFAULT_TIMEOUT = 15000;

--- a/packages/fbjs/src/fetch/fetchWithRetries.js
+++ b/packages/fbjs/src/fetch/fetchWithRetries.js
@@ -33,7 +33,7 @@ export type InitWithRetries = {
 
 const DEFAULT_TIMEOUT = 15000;
 const DEFAULT_RETRIES = [1000, 3000];
-const DEFAULT_ONERROR = function(error) { return true; };
+const DEFAULT_ONERROR = function(error, init) { return false; };
 
 /**
  * Makes a POST request to the server with the given data as the payload.
@@ -111,17 +111,17 @@ function fetchWithRetries(
      * Schedules another run of sendTimedRequest based on how much time has
      * passed between the time the last request was sent and now.
      */
-		function retryRequest(retryDirectly: boolean = false): void {
-			if(retryDirectly) {
-				sendTimedRequest();
-			}
-			else {
-				const retryDelay = _retryDelays[requestsAttempted - 1];
-				const retryStartTime = requestStartTime + retryDelay;
-				// Schedule retry for a configured duration after last request started.
-				setTimeout(sendTimedRequest, retryStartTime - Date.now());
-			}
-		}
+    function retryRequest(retryDirectly: boolean = false): void {
+        if(retryDirectly) {
+            sendTimedRequest();
+        }
+        else {
+            const retryDelay = _retryDelays[requestsAttempted - 1];
+            const retryStartTime = requestStartTime + retryDelay;
+            // Schedule retry for a configured duration after last request started.
+            setTimeout(sendTimedRequest, retryStartTime - Date.now());
+        }
+    }
 
     /**
      * Checks if another attempt should be done to send a request to the server.


### PR DESCRIPTION
I use it like this: return true directly retries request.

```
var token = localStorage.getItem('jwtToken');

const g = require('../../misc/settings').graphql;
Relay.injectNetworkLayer(
	new RelayNetworkLayer('http://'+g.host+':'+g.port+'/graphql', {
		headers: (token ? {
			Authorization: 'Bearer ' + token
		} : {}),
		onError: (error, init) => {
			console.log(error);
			if(error.status == 400 || error.status == 500) {
				//localStorage.removeItem('jwtToken');
				delete init.headers['Authorization'];
				console.log('removed token');
				return true;
			}
			return false;
		}
	})
);
```