### PR TITLE
Change console.error to console.warn in warning function

### DIFF
--- a/packages/fbjs/src/__forks__/warning.js
+++ b/packages/fbjs/src/__forks__/warning.js
@@ -27,7 +27,7 @@ if (__DEV__) {
     var argIndex = 0;
     var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
     if (typeof console !== 'undefined') {
-      console.error(message);
+      console.warn(message);
     }
     try {
       // --- Welcome to debugging React ---


### PR DESCRIPTION
I find that error logging is jarring when what's actually displayed is a warning. Really small change to use the console.warn instead of console.error to generate appropriate styling in the debug console.