### PR TITLE
[fbjs] Move DEV check out of invariant itself

### DIFF
--- a/packages/fbjs/src/__forks__/invariant.js
+++ b/packages/fbjs/src/__forks__/invariant.js
@@ -22,12 +22,18 @@
  * will remain to ensure logic does not differ in production.
  */
 
-function invariant(condition, format, a, b, c, d, e, f) {
-  if (__DEV__) {
+var validateFormat = function(format) {};
+
+if (__DEV__) {
+  validateFormat = function(format) {
     if (format === undefined) {
       throw new Error('invariant requires an error message argument');
     }
-  }
+  };
+}
+
+function invariant(condition, format, a, b, c, d, e, f) {
+  validateFormat(format);
 
   if (!condition) {
     var error;


### PR DESCRIPTION
This allows us to only check DEV (or process.env.NODE_ENV) only once, at module initialization time, instead of during each call to invariant. But otherwise should maintain the current behavior.

cc @spicyj @cpojer @jeanlauliac @davidaurelio