### PR TITLE
Fix flow typings of partitionObjectByKey

### DIFF
--- a/packages/fbjs/package.json
+++ b/packages/fbjs/package.json
@@ -18,7 +18,7 @@
     "babel-preset-fbjs": "file:../babel-preset-fbjs",
     "del": "^2.2.0",
     "fbjs-scripts": "file:../fbjs-scripts",
-    "flow-bin": "^0.36.0",
+    "flow-bin": "^0.38.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-flatten": "^0.2.0",

--- a/packages/fbjs/src/.flowconfig
+++ b/packages/fbjs/src/.flowconfig
@@ -8,4 +8,4 @@
 module.system=haste
 
 [version]
-^0.36.0
+^0.38.0

--- a/packages/fbjs/src/functional/partitionObjectByKey.js
+++ b/packages/fbjs/src/functional/partitionObjectByKey.js
@@ -21,7 +21,7 @@ var partitionObject = require('partitionObject');
 function partitionObjectByKey(
   source: Object,
   whitelist: Set<string>
-): Array<Object> {
+): [Object, Object] {
   return partitionObject(source, (_, key) => whitelist.has(key));
 }
 


### PR DESCRIPTION
`flow-bin@0.38.0` will throw the following error:
```bash
src/functional/partitionObjectByKey.js:25
 25:   return partitionObject(source, (_, key) => whitelist.has(key));
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ tuple type. This type is incompatible with the expected return type of
 24: ): Array<Object> {
        ^^^^^^^^^^^^^ array type
```

This PR fixes the flow typings of `partitionObjectByKey` to match [`partitionObject`](https://github.com/facebook/fbjs/blob/master/packages/fbjs/src/functional/partitionObject.js#L18).

We discovered this problem in https://github.com/nteract/nteract/pull/1349 while trying to upgrade `flow-bin`.