### PR TITLE
add mouse event for ReactWheelHandler handleScrollX / handleScrollY

### DIFF
--- a/packages/fbjs/src/dom/ReactWheelHandler.js
+++ b/packages/fbjs/src/dom/ReactWheelHandler.js
@@ -65,8 +65,8 @@ class ReactWheelHandler {
     const normalizedEvent = normalizeWheel(event);
     const deltaX = this._deltaX + normalizedEvent.pixelX;
     const deltaY = this._deltaY + normalizedEvent.pixelY;
-    const handleScrollX = this._handleScrollX(deltaX, deltaY);
-    const handleScrollY = this._handleScrollY(deltaY, deltaX);
+    const handleScrollX = this._handleScrollX(deltaX, deltaY, event);
+    const handleScrollY = this._handleScrollY(deltaY, deltaX, event);
     if (!handleScrollX && !handleScrollY) {
       return;
     }


### PR DESCRIPTION
The event.preventDefault() in onWheel breaks the browser zoom in / out while holding the ctrl key and scrolling using the mouse wheel.
A fix for this can be done if we return false from handleScrollX / handleScrollY.
In order to return false we need to see that ctrl is pressed and for this we need the event.

In my opinion, I find that passing the event is useful and also this is a non breaking change since it is passed as the last argument in the list.

Please see https://github.com/schrodinger/fixed-data-table-2/issues/113 for the actual use case.