### PR TITLE
Make getActiveElement work without document global

### DIFF
--- a/src/core/dom/getActiveElement.js
+++ b/src/core/dom/getActiveElement.js
@@ -23,10 +23,10 @@
  * @return {?DOMElement}
  */
 function getActiveElement(doc) /*?DOMElement*/ {
-  doc = doc || document;
-  if (typeof doc === 'undefined') {
+  if (!doc && typeof document === 'undefined') {
     return null;
   }
+  doc = doc || document;
   try {
     return doc.activeElement || doc.body;
   } catch (e) {


### PR DESCRIPTION
🌶🔧 to address https://github.com/facebook/fbjs/pull/222#issuecomment-287978117 and https://github.com/facebook/fbjs/pull/222#issuecomment-288073788

Tests and server-side rendering are breaking when no global document exists (an oversight from the original PR). This seems like a clean way to solve it.