### PR TITLE
Make getActiveElement work without document global (for master)

### DIFF
--- a/packages/fbjs/src/core/dom/getActiveElement.js
+++ b/packages/fbjs/src/core/dom/getActiveElement.js
@@ -23,10 +23,10 @@
  * @return {?DOMElement}
  */
 function getActiveElement(doc) /*?DOMElement*/ {
-  doc = doc || document;
-  if (typeof doc === 'undefined') {
+  if (!doc && typeof document === 'undefined') {
     return null;
   }
+  doc = doc || document;
   try {
     return doc.activeElement || doc.body;
   } catch (e) {


### PR DESCRIPTION
Dupe of #223, but for master.