### PR TITLE
Use global.document in getActiveElement

### DIFF
--- a/packages/fbjs/src/core/dom/getActiveElement.js
+++ b/packages/fbjs/src/core/dom/getActiveElement.js
@@ -23,7 +23,7 @@
  * @return {?DOMElement}
  */
 function getActiveElement(doc) /*?DOMElement*/ {
-  doc = doc || document;
+  doc = doc || global.document;
   if (typeof doc === 'undefined') {
     return null;
   }


### PR DESCRIPTION
Referencing `document` here throws an error in Node.
Using `global.document` avoids this.

Fixes #225