### PR TITLE
Try document.scrollingElement first in getDocumentScrollElement

### DIFF
--- a/packages/fbjs/src/core/dom/getDocumentScrollElement.js
+++ b/packages/fbjs/src/core/dom/getDocumentScrollElement.js
@@ -27,6 +27,9 @@ const isWebkit =
  */
 function getDocumentScrollElement(doc) {
   doc = doc || document;
+  if (doc.scrollingElement) {
+    return doc.scrollingElement;
+  }
   return !isWebkit && doc.compatMode === 'CSS1Compat' ?
     doc.documentElement :
     doc.body;


### PR DESCRIPTION
This fixes draft-js#14 for Chrome with "Experimental Web Platform" enabled.
https://github.com/facebook/draft-js/issues/14