### PR TITLE
Fix: use console.warn instead of console.error in DEV

### DIFF
--- a/packages/fbjs/src/__forks__/warning.js
+++ b/packages/fbjs/src/__forks__/warning.js
@@ -27,7 +27,7 @@ if (__DEV__) {
     var argIndex = 0;
     var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
     if (typeof console !== 'undefined') {
-      console.error(message);
+      console.warn(message);
     }
     try {
       // --- Welcome to debugging React ---

--- a/packages/fbjs/src/fetch/__tests__/fetchWithRetries-test.js
+++ b/packages/fbjs/src/fetch/__tests__/fetchWithRetries-test.js
@@ -28,7 +28,7 @@ describe('fetchWithRetries', () => {
 
     handleNext = jest.fn();
 
-    spyOn(console, 'error').and.callFake(message => {
+    spyOn(console, 'warn').and.callFake(message => {
       expect(message).toBe(
         'Warning: fetchWithRetries: HTTP timeout, retrying.'
       );

--- a/packages/fbjs/src/stubs/EventListener.js
+++ b/packages/fbjs/src/stubs/EventListener.js
@@ -68,7 +68,7 @@ var EventListener = {
       };
     } else {
       if (__DEV__) {
-        console.error(
+        console.warn(
           'Attempted to listen to events during the capture phase on a ' +
           'browser that does not support the capture phase. Your application ' +
           'will not receive some events.'


### PR DESCRIPTION
Rationale:

1. The call sites I modified are actual warnings, so it's not appropriate to trigger what looks like a hard error to the user. It comes off as being relatively developer-hostile.

2. Some build systems monitor console.error and will fail their respective builds if anything looking like a hard error is logged. This is especially an issue now with all the prop-types and createClass deprecation messages that are not straightforward to find and fix.