### PR TITLE
inline-requires handles Identifiers declared before CallExpressions

### DIFF
--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -47,6 +47,21 @@ describe('inline-requires', function() {
       ]);
     }).toThrow();
   });
+
+  it('should properly handle identifiers declared before their corresponding require statement', function() {
+    compare([
+      'function foo() {',
+      'bar();',
+      '}',
+      'var bar = require("baz");',
+      'foo();',
+    ], [
+      'function foo() {',
+      'require("baz")();',
+      '}',
+      'foo();',
+    ]);
+  });
 });
 
 function transform(input) {

--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -55,11 +55,13 @@ describe('inline-requires', function() {
       '}',
       'var bar = require("baz");',
       'foo();',
+      'bar();',
     ], [
       'function foo() {',
       'require("baz")();',
       '}',
       'foo();',
+      'require("baz")();',
     ]);
   });
 });


### PR DESCRIPTION
While syncing the latest React release to fbsource I discovered an improperly handled inlining case.

Essentially this:
```js
function foo() {
  bar();
}
var bar = require('baz');
foo();
```

Became this (and errored because `bar` was undefined):
```js
function foo() {
  bar();
}
foo();
```

After this bugfix it becomes:
```js
function foo() {
  require("baz")();
}
foo();
```