### PR TITLE
Make inline-require transform compatible with other transforms

### DIFF
--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -70,7 +70,8 @@ describe('inline-requires', function() {
       'import Imported from "foo";',
       'console.log(Imported);',
     ], [
-      'var _foo2 = _interopRequireDefault(require("foo"));',
+      'var _foo = require("foo");',
+      'var _foo2 = _interopRequireDefault(_foo);',
       'function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }',
       'console.log(_foo2.default);',
     ]);

--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -51,24 +51,38 @@ describe('inline-requires', function() {
   it('should properly handle identifiers declared before their corresponding require statement', function() {
     compare([
       'function foo() {',
-      'bar();',
+      '  bar();',
       '}',
       'var bar = require("baz");',
       'foo();',
       'bar();',
     ], [
       'function foo() {',
-      'require("baz")();',
+      '  require("baz")();',
       '}',
       'foo();',
       'require("baz")();',
+    ]);
+  });
+
+  it('should be compatible with other transforms like transform-es2015-modules-commonjs', function() {
+    compare([
+      'import Imported from "foo";',
+      'console.log(Imported);',
+    ], [
+      'var _foo2 = _interopRequireDefault(require("foo"));',
+      'function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }',
+      'console.log(_foo2.default);',
     ]);
   });
 });
 
 function transform(input) {
   return babel.transform(normalise(input), {
-    plugins: [require('../inline-requires.js')],
+    plugins: [
+      [require('babel-plugin-transform-es2015-modules-commonjs'), {strict: false}],
+      require('../inline-requires.js')
+    ],
   }).code;
 }
 
@@ -83,5 +97,5 @@ function compare(input, output) {
 }
 
 function strip(input) {
-  return input.replace(/\s/g, '');
+  return input.trim().replace(/\n\n/g, '\n');
 }

--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -70,8 +70,7 @@ describe('inline-requires', function() {
       'import Imported from "foo";',
       'console.log(Imported);',
     ], [
-      'var _foo = require("foo");',
-      'var _foo2 = _interopRequireDefault(_foo);',
+      'var _foo2 = _interopRequireDefault(require(\"foo\"));',
       'function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }',
       'console.log(_foo2.default);',
     ]);

--- a/packages/babel-preset-fbjs/plugins/inline-requires.js
+++ b/packages/babel-preset-fbjs/plugins/inline-requires.js
@@ -18,6 +18,17 @@
 var inlineRequiredDependencyMap;
 
 /**
+ * Map of variable names that were not inlined.
+ */
+var unmappedIdentifiersMap;
+
+/**
+ * Do a second transform pass on the current Program to catch skipped variables.
+ * This covers an edge-case where we remove a require() after passing references to it.
+ */
+var orphanedIdentifiersFound;
+
+/**
  * This transform inlines top-level require(...) aliases with to enable lazy
  * loading of dependencies.
  *
@@ -36,12 +47,54 @@ module.exports = function fbjsInlineRequiresTransform(babel) {
     return call;
   }
 
-  /**
-   * Collect top-level require(...) aliases.
-   */
-  var firstPassVisitor = {
-    CallExpression: {
-      enter(path) {
+  function Identifier(path) {
+    var node = path.node;
+    var parent = path.parent;
+    var scope = path.scope;
+
+    if (!shouldInlineRequire(node, scope)) {
+      // Monitor this variable name in case we later remove its require().
+      // This won't happen often but if it does we need to do a second pass.
+      unmappedIdentifiersMap[node.name] = true;
+
+      return;
+    }
+
+    if (
+      parent.type === 'AssignmentExpression' &&
+      path.isBindingIdentifier() &&
+      !scope.bindingIdentifierEquals(node.name, node)
+    ) {
+      throw new Error(
+        'Cannot assign to a require(...) alias, ' + node.name +
+        '. Line: ' + node.loc.start.line + '.'
+      );
+    }
+
+    path.replaceWith(
+      path.isReferenced() ? buildRequireCall(node.name) : node
+    );
+  }
+
+  return {
+    visitor: {
+      Program: {
+        enter: function() {
+          resetCollection();
+        },
+        exit: function(path, state) {
+          // If we removed require() statements for variables we've already seen,
+          // We need to do a second pass on this program to replace them with require().
+          if (orphanedIdentifiersFound) {
+            path.traverse({ Identifier: Identifier }, state);
+          }
+        }
+      },
+
+      /**
+       * Collect top-level require(...) aliases.
+       */
+      CallExpression: function(path) {
         var node = path.node;
 
         if (isTopLevelRequireAlias(path)) {
@@ -50,61 +103,31 @@ module.exports = function fbjsInlineRequiresTransform(babel) {
 
           inlineRequiredDependencyMap[varName] = moduleName;
 
+          // If we removed require() statements for variables we've already seen,
+          // We need to do a second pass on this program to replace them with require().
+          if (unmappedIdentifiersMap.hasOwnProperty(varName)) {
+            orphanedIdentifiersFound = true;
+          }
+
           // Remove the declaration.
           path.parentPath.parentPath.remove();
           // And the associated binding in the scope.
           path.scope.removeBinding(varName);
         }
-      }
-    }
-  };
+      },
 
-  /**
-   * Inline require(...) aliases.
-   */
-  var secondPassVisitor = {
-    Identifier: {
-      enter(path) {
-        var node = path.node;
-        var parent = path.parent;
-        var scope = path.scope;
-
-        if (!shouldInlineRequire(node, scope)) {
-          return;
-        }
-
-        if (
-          parent.type === 'AssignmentExpression' &&
-          path.isBindingIdentifier() &&
-          !scope.bindingIdentifierEquals(node.name, node)
-        ) {
-          throw new Error(
-            'Cannot assign to a require(...) alias, ' + node.name +
-            '. Line: ' + node.loc.start.line + '.'
-          );
-        }
-
-        path.replaceWith(
-          path.isReferenced() ? buildRequireCall(node.name) : node
-        );
-      }
-    }
-  };
-
-  return {
-    visitor: {
-      Program: function(path, state) {
-        resetCollection();
-
-        path.traverse(firstPassVisitor, state);
-        path.traverse(secondPassVisitor, state);
-      }
-    }
+      /**
+       * Inline require(...) aliases.
+       */
+      Identifier: Identifier,
+    },
   };
 };
 
 function resetCollection() {
   inlineRequiredDependencyMap = {};
+  unmappedIdentifiersMap = {};
+  orphanedIdentifiersFound = false;
 }
 
 function isTopLevelRequireAlias(path) {

--- a/packages/babel-preset-fbjs/plugins/inline-requires.js
+++ b/packages/babel-preset-fbjs/plugins/inline-requires.js
@@ -93,14 +93,11 @@ module.exports = function fbjsInlineRequiresTransform(babel) {
 
   return {
     visitor: {
-      Program: {
-        enter(path, state) {
-          resetCollection();
-        },
-        exit(path, state) {
-          path.traverse(firstPassVisitor, state);
-          path.traverse(secondPassVisitor, state);
-        }
+      Program: function(path, state) {
+        resetCollection();
+
+        path.traverse(firstPassVisitor, state);
+        path.traverse(secondPassVisitor, state);
       }
     }
   };

--- a/packages/babel-preset-fbjs/plugins/inline-requires.js
+++ b/packages/babel-preset-fbjs/plugins/inline-requires.js
@@ -40,15 +40,6 @@ module.exports = function fbjsInlineRequiresTransform(babel) {
    * Collect top-level require(...) aliases.
    */
   var firstPassVisitor = {
-    Program: {
-      enter() {
-        resetCollection();
-      },
-      exit(path, state) {
-        path.traverse(secondPassVisitor, state);
-      }
-    },
-
     CallExpression: {
       enter(path) {
         var node = path.node;
@@ -101,7 +92,17 @@ module.exports = function fbjsInlineRequiresTransform(babel) {
   };
 
   return {
-    visitor: firstPassVisitor
+    visitor: {
+      Program: {
+        enter(path, state) {
+          resetCollection();
+        },
+        exit(path, state) {
+          path.traverse(firstPassVisitor, state);
+          path.traverse(secondPassVisitor, state);
+        }
+      }
+    }
   };
 };
 


### PR DESCRIPTION
My [recent changes to the inline-requires transform](https://github.com/facebook/fbjs/pull/236) caused unintended problems when ran alongside other transforms (eg 'babel-plugin-transform-es2015-modules-commonjs').

```js
// This...
import Imported from 'XHRHttpError';

// Would be transformed into this...
var _XHRHttpError2 = babelHelpers.interopRequireDefault(_XHRHttpError);
```

The fix for this is to avoid re-processing the entire AST as we may interfere with modifications made by other plug-ins. Instead the 'inline-requires' transform tracks `Identifier`s and updates them (only) if we later remove a `require` they were depending on.