### PR TITLE
Type `keyMap`

### DIFF
--- a/packages/fbjs/package.json
+++ b/packages/fbjs/package.json
@@ -18,7 +18,7 @@
     "babel-preset-fbjs": "file:../babel-preset-fbjs",
     "del": "^2.2.0",
     "fbjs-scripts": "file:../fbjs-scripts",
-    "flow-bin": "^0.38.0",
+    "flow-bin": "^0.46.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-flatten": "^0.2.0",

--- a/packages/fbjs/src/.flowconfig
+++ b/packages/fbjs/src/.flowconfig
@@ -8,4 +8,4 @@
 module.system=haste
 
 [version]
-^0.38.0
+^0.46.0

--- a/packages/fbjs/src/key-mirror/keyMirror.js
+++ b/packages/fbjs/src/key-mirror/keyMirror.js
@@ -8,6 +8,7 @@
  *
  * @providesModule keyMirror
  * @typechecks static-only
+ * @flow
  */
 
 'use strict';
@@ -32,7 +33,7 @@ var invariant = require('invariant');
  * @param {object} obj
  * @return {object}
  */
-var keyMirror = function(obj) {
+var keyMirror = function<T: {}>(obj: T): $ObjMapi<T, <K>(K) => K> {
   var ret = {};
   var key;
   invariant(

--- a/packages/fbjs/src/struct/PrefixIntervalTree.js
+++ b/packages/fbjs/src/struct/PrefixIntervalTree.js
@@ -66,7 +66,7 @@ class PrefixIntervalTree {
   /**
    * Binary heap
    */
-  _heap: Array<number>;
+  _heap: Int32Array;
 
   constructor(xs: Array<number>) {
     this._size = xs.length;


### PR DESCRIPTION
Adds flow annotations to `keyMap`, so that the return type is an object with all keys of the input object, and `string` values.