### PR TITLE
Follow a breaking change in npm@4

### DIFF
--- a/packages/fbjs-scripts/gulp/check-dependencies.js
+++ b/packages/fbjs-scripts/gulp/check-dependencies.js
@@ -35,7 +35,10 @@ module.exports = function(opts) {
     });
 
     outdated.on('exit', function(code) {
-      if (code !== 0) {
+      // exitCode set to 1 in npm 4
+      if (code === 1) {
+        process.exitCode = 0
+      } else if (code !== 0) {
         cb(new gutil.PluginError(PLUGIN_NAME, 'npm broke'));
       }
 


### PR DESCRIPTION
To fix https://github.com/facebook/draft-js/issues/914, I updated `check-dependencies` to handle a breaking change in `npm@4`. This is a quick-fix, but it's how npm handle the exitCode in the test: [npm/test/tap/outdated.js#L107-L108](https://github.com/npm/npm/blob/latest/test/tap/outdated.js#L107-L108).

Probably, we will have a better way eventually, but it may take more time.
+ https://github.com/npm/npm/pull/16703