### PR TITLE
dummyNode in markup functions

### DIFF
--- a/packages/fbjs/src/core/createNodesFromMarkup.js
+++ b/packages/fbjs/src/core/createNodesFromMarkup.js
@@ -19,12 +19,6 @@ const getMarkupWrap = require('getMarkupWrap');
 const invariant = require('invariant');
 
 /**
- * Dummy container used to render all markup.
- */
-const dummyNode =
-  ExecutionEnvironment.canUseDOM ? document.createElement('div') : null;
-
-/**
  * Pattern used by `getNodeName`.
  */
 const nodeNamePattern = /^\s*<(\w+)/;
@@ -51,6 +45,11 @@ function getNodeName(markup) {
  * @return {array<DOMElement|DOMTextNode>} An array of rendered nodes.
  */
 function createNodesFromMarkup(markup, handleScript) {
+  /**
+   * Dummy container used to render all markup.
+   */
+  const dummyNode = ExecutionEnvironment.canUseDOM ? document.createElement('div') : null;
+
   let node = dummyNode;
   invariant(!!dummyNode, 'createNodesFromMarkup dummy not initialized');
   const nodeName = getNodeName(markup);

--- a/packages/fbjs/src/core/getMarkupWrap.js
+++ b/packages/fbjs/src/core/getMarkupWrap.js
@@ -16,12 +16,6 @@ const ExecutionEnvironment = require('ExecutionEnvironment');
 const invariant = require('invariant');
 
 /**
- * Dummy container used to detect which wraps are necessary.
- */
-const dummyNode =
-  ExecutionEnvironment.canUseDOM ? document.createElement('div') : null;
-
-/**
  * Some browsers cannot use `innerHTML` to render certain elements standalone,
  * so we wrap them, render the wrapped nodes, then extract the desired node.
  *
@@ -95,6 +89,11 @@ svgElements.forEach((nodeName) => {
  * @return {?array} Markup wrap configuration, if applicable.
  */
 function getMarkupWrap(nodeName) {
+  /**
+   * Dummy container used to detect which wraps are necessary.
+   */
+  const dummyNode = ExecutionEnvironment.canUseDOM ? document.createElement('div') : null;
+  
   invariant(!!dummyNode, 'Markup wrapping node not initialized');
   if (!markupWrap.hasOwnProperty(nodeName)) {
     nodeName = '*';


### PR DESCRIPTION
Moved _dummyNode_ constant inside _createNodesFromMarkup_ and _getMarkupWrap_ functions.

While working on React project and using React Test Utils with JSDOM for unit tests, it makes complication when the _dummyNode_ constant is set once on the initial run of app.
When JSDOM is used to create globals _document_ and _window_ variables during tests, it is possible to update the _ExecutionEnvironment.canUseDOM_ flag, however the _dummyNode_ is not updated with it so it is not consistent during tests.
Using it inside functions provide possibility to get updated _canUseDOM_ flag and create document element for proper unit test experience.