### PR TITLE
[fbjs-scripts] Handle npm outdated exit codes

### DIFF
--- a/packages/fbjs-scripts/gulp/check-dependencies.js
+++ b/packages/fbjs-scripts/gulp/check-dependencies.js
@@ -35,11 +35,15 @@ module.exports = function(opts) {
     });
 
     outdated.on('exit', function(code) {
-      if (code !== 0) {
+      // npm outdated now exits with non-zero when there are outdated deps, so
+      // we'll handle that gracefully across npm versions and just assume that
+      // things are fine unless we can't parse stdout as JSON.
+      try {
+        var outdatedData = JSON.parse(data);
+      } catch (e) {
         cb(new gutil.PluginError(PLUGIN_NAME, 'npm broke'));
       }
 
-      var outdatedData = JSON.parse(data);
       var failures = [];
       Object.keys(outdatedData).forEach(function(name) {
         var current = outdatedData[name].current;


### PR DESCRIPTION
Alternative to #242, not relying on return codes at all but just blindly parsing the JSON.

Does this make sense @watilde? I haven't tested the output of `npm outdated` here to see if this will be versatile enough but I want to assume it's ok and would work across versions without issue. Or is the output still going to be JSON formatted errors? (given my experience with npm that seems doubtful).

Thanks for the idea to ignore status codes entirely @wwalser 👍