### PR TITLE
Wrapped exported setImmediate in a pass-trough function, so it doesnt…

### DIFF
--- a/packages/fbjs/src/__forks__/setImmediate.js
+++ b/packages/fbjs/src/__forks__/setImmediate.js
@@ -13,5 +13,6 @@
 
 // setimmediate adds setImmediate to the global. We want to make sure we export
 // the actual function.
-require('setimmediate')
-module.exports = global.setImmediate;
+require('setimmediate');
+module.exports = (...args) => global.setImmediate(...args);
+


### PR DESCRIPTION
… lose its global context - fixing "Invalid calling object" error in IE and Edge

It will fix issues in dependant packages such as https://github.com/facebook/draft-js/issues/1230

The issue was somehow introduced by webpack3 different module handling (aint sure about exact changes which caused it, didnt have time to investigate, but itd definitely related).

I wasnt sure about code-style, so if you let me know I can ammend it to use arrow function or smth.