### PR TITLE
add 'instrument' flag to createCacheKey fn

### DIFF
--- a/packages/fbjs-scripts/jest/createCacheKeyFunction.js
+++ b/packages/fbjs-scripts/jest/createCacheKeyFunction.js
@@ -22,8 +22,12 @@ function buildCacheKey(files, base) {
 module.exports = files => {
   const presetVersion = require('../package').dependencies['babel-preset-fbjs'];
   const cacheKey = buildCacheKey(files, presetVersion);
-  return (src, file, configString) => crypto.createHash('md5')
-    .update(cacheKey)
-    .update(src + file + configString)
-    .digest('hex');
+  return (src, file, configString, options) => {
+    return crypto
+      .createHash('md5')
+      .update(cacheKey)
+      .update(src + file + configString)
+      .update(options && options.instrument ? 'instrument' : '')
+      .digest('hex');
+  };
 };


### PR DESCRIPTION
Jest uses an extra option to differentiate intstrumented cache files from non-instrumented (https://github.com/facebook/jest/blob/master/packages/jest-runtime/src/script_transformer.js#L70-L72)
and it seems like fbsource is failing to collect coverage without this option