### PR TITLE
Sync over argument arity fixes for stricter Flow updates

### DIFF
--- a/packages/fbjs/CHANGELOG.md
+++ b/packages/fbjs/CHANGELOG.md
@@ -11,6 +11,8 @@
 - More flow annotations: `joinClasses`, `flatMapArray`
 - Upgraded `core-js` dependency to ^2.4.1
 
+### Fixed
+- Fixed strict argument arity issues with `Deferred` module.
 
 ## [0.8.5] - 2016-09-27
 

--- a/packages/fbjs/src/core/Deferred.js
+++ b/packages/fbjs/src/core/Deferred.js
@@ -56,7 +56,10 @@ class Deferred<Tvalue, Treason> {
     return Promise.prototype.then.apply(this._promise, arguments);
   }
 
-  done(): void {
+  done(
+    onFulfill?: ?(value: any) => mixed,
+    onReject?: ?(error: any) => mixed
+  ): void {
     // Embed the polyfill for the non-standard Promise.prototype.done so that
     // users of the open source fbjs don't need a custom lib for Promise
     const promise = arguments.length ?

--- a/packages/fbjs/src/core/Deferred.js
+++ b/packages/fbjs/src/core/Deferred.js
@@ -48,11 +48,16 @@ class Deferred<Tvalue, Treason> {
     this._reject(reason);
   }
 
-  catch(): Promise<any> {
+  catch(
+    onReject?: ?(error: any) => mixed
+  ): Promise<any> {
     return Promise.prototype.catch.apply(this._promise, arguments);
   }
 
-  then(): Promise<any> {
+  then(
+    onFulfill?: ?(value: any) => mixed,
+    onReject?: ?(error: any) => mixed
+  ): Promise<any> {
     return Promise.prototype.then.apply(this._promise, arguments);
   }
 


### PR DESCRIPTION
Ignoring the eslint stuff, which I guess I forgot to push to master the other day (will fix in a bit)…

This should fix some of the issues that Relay is seeing, but it was pointed out that `then` should also be causing issues. Looking at https://github.com/facebook/relay/commit/68241f7c9126b6c44646ffb078df63c2e3810d43, it seems like those were probably just blanketed over with fixmes.