### PR TITLE
Allow babel-eslint 8 in eslint-config-fbjs

### DIFF
--- a/packages/eslint-config-fbjs/package.json
+++ b/packages/eslint-config-fbjs/package.json
@@ -19,7 +19,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "^7.2.3 || ^8.0.0",
     "eslint": "^4.2.0",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-flowtype": "^2.35.0",


### PR DESCRIPTION
There are no breaking changes, it just uses babel@7 under the hood.

https://github.com/babel/babel-eslint/releases/tag/v8.0.0