### PR TITLE
Fix getText to handle IE 11 reporting a data transfer type of 'Text'

### DIFF
--- a/packages/fbjs/src/datatransfer/DataTransfer.js
+++ b/packages/fbjs/src/datatransfer/DataTransfer.js
@@ -75,7 +75,7 @@ class DataTransfer {
   getText() {
     var text;
     if (this.data.getData) {
-      if (!this.types.length) {
+      if (!this.types.length || this.types.indexOf('Text' !== -1)) {
         text = this.data.getData('Text');
       } else if (this.types.indexOf('text/plain') != -1) {
         text = this.data.getData('text/plain');


### PR DESCRIPTION
In IE10 the data transfer types are empty, but in IE11 they are specified as 'Text'.

This means that the current implementation fails to get the text from the data transfer object in IE11, but this is easily fixed by checking if the data transfer types contain the special IE11 type.