### PR TITLE
eslint plugins: Synchronize dependency versions between -opensource and standard eslint configs

### DIFF
--- a/packages/eslint-config-fbjs-opensource/README.md
+++ b/packages/eslint-config-fbjs-opensource/README.md
@@ -8,28 +8,12 @@ This configuration is a new ideal setup based on Facebook's internal configurati
 
 #### `npm`
 ```sh
-npm install --save-dev \
-  eslint-config-fbjs-opensource \
-  eslint-plugin-babel \
-  eslint-plugin-flowtype \
-  eslint-plugin-react \
-  eslint-plugin-jasmine \
-  eslint-plugin-prefer-object-spread \
-  eslint \
-  babel-eslint
+npm install --save-dev eslint eslint-config-fbjs-opensource
 ```
 
 #### `yarn`
 ```sh
-yarn add --dev \
-  eslint-config-fbjs-opensource \
-  eslint-plugin-babel \
-  eslint-plugin-flowtype \
-  eslint-plugin-react \
-  eslint-plugin-jasmine \
-  eslint-plugin-prefer-object-spread \
-  eslint \
-  babel-eslint
+yarn add --dev eslint eslint-config-fbjs-opensource
 ```
 
 ### Configure

--- a/packages/eslint-config-fbjs-opensource/README.md
+++ b/packages/eslint-config-fbjs-opensource/README.md
@@ -8,12 +8,28 @@ This configuration is a new ideal setup based on Facebook's internal configurati
 
 #### `npm`
 ```sh
-npm install --save-dev eslint eslint-config-fbjs-opensource
+npm install --save-dev \
+  eslint-config-fbjs-opensource \
+  eslint-plugin-babel \
+  eslint-plugin-flowtype \
+  eslint-plugin-react \
+  eslint-plugin-jasmine \
+  eslint-plugin-prefer-object-spread \
+  eslint \
+  babel-eslint
 ```
 
 #### `yarn`
 ```sh
-yarn add --dev eslint eslint-config-fbjs-opensource
+yarn add --dev \
+  eslint-config-fbjs-opensource \
+  eslint-plugin-babel \
+  eslint-plugin-flowtype \
+  eslint-plugin-react \
+  eslint-plugin-jasmine \
+  eslint-plugin-prefer-object-spread \
+  eslint \
+  babel-eslint
 ```
 
 ### Configure

--- a/packages/eslint-config-fbjs-opensource/index.js
+++ b/packages/eslint-config-fbjs-opensource/index.js
@@ -90,6 +90,7 @@ module.exports = {
     'eqeqeq': [1, 'allow-null'],
     'guard-for-in': 0,
     'no-alert': 1,
+    'no-await-in-loop': 1,
     'no-caller': 2,
     'no-case-declarations': 1,
     'no-div-regex': 1,
@@ -295,8 +296,7 @@ module.exports = {
     'babel/new-cap': 0,
     'babel/object-curly-spacing': 0,
     'babel/no-invalid-this': 0,
-    // Babel (not in eslint)
-    'babel/no-await-in-loop': 1,
+    'babel/no-await-in-loop': 0, // deprecated; now using 'no-await-in-loop' from eslint core
 
     // flowtype (https://github.com/gajus/eslint-plugin-flowtype)
     'flowtype/boolean-style': 1,
@@ -386,8 +386,7 @@ module.exports = {
     'react/jsx-no-undef': 2,
     'react/jsx-pascal-case': 0,
     'react/jsx-sort-props': 0,
-    'react/jsx-space-before-closing': 1,
-    'react/jsx-tag-spacing': 1,
+    'react/jsx-tag-spacing': [1, {beforeSelfClosing: 'always'}],
     'react/jsx-uses-react': 1,
     'react/jsx-uses-vars': 1,
     'react/jsx-wrap-multilines': 1,

--- a/packages/eslint-config-fbjs-opensource/package.json
+++ b/packages/eslint-config-fbjs-opensource/package.json
@@ -13,15 +13,15 @@
     "warning.js"
   ],
   "dependencies": {
-    "babel-eslint": "^7.1.1",
-    "eslint-plugin-babel": "^4.0.1",
-    "eslint-plugin-flowtype": "^2.30.0",
-    "eslint-plugin-jasmine": "^2.2.0",
-    "eslint-plugin-prefer-object-spread": "^1.1.0",
-    "eslint-plugin-react": "^6.9.0",
     "fbjs-eslint-utils": "^1.0.0"
   },
   "peerDependencies": {
-    "eslint": "^3.0.0"
+    "babel-eslint": "^7.2.3",
+    "eslint": "^4.2.0",
+    "eslint-plugin-babel": "^4.1.1",
+    "eslint-plugin-flowtype": "^2.35.0",
+    "eslint-plugin-jasmine": "^2.2.0",
+    "eslint-plugin-prefer-object-spread": "^1.1.0",
+    "eslint-plugin-react": "^7.1.0"
   }
 }

--- a/packages/eslint-config-fbjs-opensource/package.json
+++ b/packages/eslint-config-fbjs-opensource/package.json
@@ -13,15 +13,15 @@
     "warning.js"
   ],
   "dependencies": {
-    "fbjs-eslint-utils": "^1.0.0"
-  },
-  "peerDependencies": {
     "babel-eslint": "^7.2.3",
-    "eslint": "^4.2.0",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-jasmine": "^2.2.0",
     "eslint-plugin-prefer-object-spread": "^1.1.0",
-    "eslint-plugin-react": "^7.1.0"
+    "eslint-plugin-react": "^7.1.0",
+    "fbjs-eslint-utils": "^1.0.0"
+  },
+  "peerDependencies": {
+    "eslint": "^4.2.0"
   }
 }


### PR DESCRIPTION
This makes the -opensource version of the config use the same versions
of dependencies as the "standard" flavor.

~~It also, like the standard flavor, makes all eslint plugins
peerDependencies, and instructs the user to install them all in the
README.~~