### PR TITLE
Add memoization to hyphenateStyleName

### DIFF
--- a/packages/fbjs/src/core/hyphenateStyleName.js
+++ b/packages/fbjs/src/core/hyphenateStyleName.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const hyphenate = require('hyphenate');
+const memoizeStringOnly = require('memoizeStringOnly');
 
 const msPattern = /^ms-/;
 
@@ -34,4 +35,4 @@ function hyphenateStyleName(string) {
   return hyphenate(string).replace(msPattern, '-ms-');
 }
 
-module.exports = hyphenateStyleName;
+module.exports = memoizeStringOnly(hyphenateStyleName);


### PR DESCRIPTION
I'm working on a patch for React that calls this function, and thought it may be worth adding memoization.

I didn't know about this function until today, and would also like to use it another project in place of [this dependency](https://github.com/rexxars/hyphenate-style-name/blob/master/index.js) which memoizes the result.