### PR TITLE
fix for isWebkit check in getDocumentScrollElement.js. Not checkin the existence of userAgent property breaks things when this library is used in react-native

### DIFF
--- a/packages/fbjs/src/core/dom/getDocumentScrollElement.js
+++ b/packages/fbjs/src/core/dom/getDocumentScrollElement.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const isWebkit =
-  typeof navigator !== 'undefined' &&
+  typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string' &&
   navigator.userAgent.indexOf('AppleWebKit') > -1;
 
 /**


### PR DESCRIPTION
The check for isWebkit checks for existence of navigator in the global scope but does not check for the existence of userAgent property on the navigator object. This breaks all libraries which use fbjs in react-native. 

I tried using draft-js in react-native and this check crashed the app on launch because react-native just creates an empty object for global.navigator.