### PR TITLE
bump ua-parser-js to fix RegExp DoS vulnerability

### DIFF
--- a/packages/fbjs/package.json
+++ b/packages/fbjs/package.json
@@ -65,7 +65,7 @@
     "object-assign": "^4.1.0",
     "promise": "^7.1.1",
     "setimmediate": "^1.0.5",
-    "ua-parser-js": "^0.7.9"
+    "ua-parser-js": "^0.7.18"
   },
   "devEngines": {
     "node": ">=4.x",


### PR DESCRIPTION
Bump `ua-parser-js` to fix Regular Expression Denial of Service (ReDoS) detected by Snyk.io.

Snyk vulnerability info page:
https://snyk.io/vuln/npm:ua-parser-js:20180227

Original issue:
https://github.com/faisalman/ua-parser-js/issues/315

Refs #286, #289 - same change, but without `package.json` reformat.