### PR TITLE
Fix Promise.finally Non-standard behavior

### DIFF
--- a/packages/fbjs/src/__forks__/Promise.native.js
+++ b/packages/fbjs/src/__forks__/Promise.native.js
@@ -18,8 +18,13 @@ require('promise/setimmediate/done');
 /**
  * Handle either fulfillment or rejection with the same callback.
  */
-Promise.prototype.finally = function(onSettled) {
-  return this.then(onSettled, onSettled);
-};
+Promise.prototype.finally = function(callback) {
+  return this.then(
+    value => Promise.resolve(callback()).then(() => value),
+    reason => Promise.resolve(callback()).then(() => {
+      throw reason;
+    })
+  );
+}
 
 module.exports = Promise;


### PR DESCRIPTION
Standard behavior: [Promise.prototype.finally()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally)

Related issue: [#19490](https://github.com/facebook/react-native/issues/19490), [#132](https://github.com/facebook/fbjs/issues/132)