### PR TITLE
Allow eslint-plugin-babel 5 in eslint-config-fbjs

### DIFF
--- a/packages/eslint-config-fbjs/package.json
+++ b/packages/eslint-config-fbjs/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "babel-eslint": "^7.2.3 || ^8.0.0",
     "eslint": "^4.2.0",
-    "eslint-plugin-babel": "^4.1.1",
+    "eslint-plugin-babel": "^4.1.1 || ^5.0.0",
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.1.0",


### PR DESCRIPTION
There should not be any breaking changes, as ESLint 4 is already required 
https://github.com/babel/eslint-plugin-babel/releases/tag/v5.0.0