### PR TITLE
Destructuring requires

### DIFF
--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -21,6 +21,34 @@ describe('inline-requires', function() {
     ]);
   });
 
+  it('should inline multiple usage', function() {
+    compare([
+      'var foo = require("foo");',
+      'foo.bar()',
+      'foo.baz()',
+    ], [
+      'require("foo").bar();',
+      'require("foo").baz();',
+    ]);
+  });
+
+  it('should not matter the variable declaration length', function() {
+    compare([
+      'var foo = require("foo"), bar = require("bar"), baz = 4;',
+      'foo.method()',
+    ], [
+      'var baz = 4;',
+      'require("foo").method();',
+    ]);
+
+    compare([
+      'var foo = require("foo"), bar = require("bar");',
+      'foo.method()',
+    ], [
+      'require("foo").method();',
+    ]);
+  });
+
   it('should inline requires that are not assigned', function() {
     compare([
       'require("foo");',
@@ -43,7 +71,21 @@ describe('inline-requires', function() {
         'var foo = require("foo");',
         'foo = "bar";',
       ]);
-    }).toThrow();
+    }).toThrow(ReferenceError);
+
+    expect(function() {
+      transform([
+        'var foo = require("foo");',
+        'foo = "bar";',
+      ]);
+    }).toThrow(/\bline: 2\b/);
+
+    expect(function() {
+      transform([
+        'var foo = require("foo");',
+        'foo = "bar";',
+      ]);
+    }).toThrow(/\bname: foo\b/);
   });
 
   it('should properly handle identifiers declared before their corresponding require statement', function() {
@@ -60,6 +102,22 @@ describe('inline-requires', function() {
       '}',
       'foo();',
       'require("baz")();',
+    ]);
+  });
+
+  it('should be compatible with destructuring', function() {
+    compare([
+      'var tmp = require("./a");',
+      'var a = tmp.a',
+      'var D = {',
+      '  b: function(c) { c ? a(c.toString()) : a("No c!"); },',
+      '};',
+    ], [
+      'var D = {',
+      '  b: function (c) {',
+      '    c ? require("./a").a(c.toString()) : require("./a").a("No c!");',
+      '  }',
+      '};',
     ]);
   });
 

--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -68,22 +68,22 @@ describe('inline-requires', function() {
       'import Imported from "foo";',
       'console.log(Imported);',
     ], [
-      'var _foo2 = _interopRequireDefault(require(\"foo\"));',
+      'var _foo2 = _interopRequireDefault(require("foo"));',
       'function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }',
       'console.log(_foo2.default);',
     ]);
   });
 
   it('should be compatible with `transform-es2015-modules-commonjs` when using named imports', function() {
-    compare(`
-      import { a } from './a';
-
-      var D = {
-        b: function(c) { c ? a(c.toString()) : a('No c!'); },
-      };`, [
+    compare([
+      'import {a} from "./a";',
+      'var D = {',
+      '  b: function(c) { c ? a(c.toString()) : a("No c!"); },',
+      '};',
+    ], [
       'var D = {',
       '  b: function (c) {',
-      `    c ? (0, require('./a').a)(c.toString()) : (0, require('./a').a)('No c!');`,
+      '    c ? (0, require("./a").a)(c.toString()) : (0, require("./a").a)("No c!");',
       '  }',
       '};',
     ]);

--- a/packages/fbjs/src/__forks__/warning.js
+++ b/packages/fbjs/src/__forks__/warning.js
@@ -18,34 +18,33 @@ var emptyFunction = require('emptyFunction');
  * same logic and follow the same code paths.
  */
 
-var warning = emptyFunction;
 
-if (__DEV__) {
-  function printWarning(format, ...args) {
-    var argIndex = 0;
-    var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
-    if (typeof console !== 'undefined') {
-      console.error(message);
-    }
-    try {
-      // --- Welcome to debugging React ---
-      // This error was thrown as a convenience so that you can use this stack
-      // to find the callsite that caused this warning to fire.
-      throw new Error(message);
-    } catch (x) {}
+function printWarning(format, ...args) {
+  var argIndex = 0;
+  var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
+  if (typeof console !== 'undefined') {
+    console.error(message);
   }
-
-  warning = function(condition, format, ...args) {
-    if (format === undefined) {
-      throw new Error(
-        '`warning(condition, format, ...args)` requires a warning ' +
-        'message argument'
-      );
-    }
-    if (!condition) {
-      printWarning(format, ...args);
-    }
-  };
+  try {
+    // --- Welcome to debugging React ---
+    // This error was thrown as a convenience so that you can use this stack
+    // to find the callsite that caused this warning to fire.
+    throw new Error(message);
+  } catch (x) {}
 }
+
+var warning = __DEV__
+  ? function(condition, format, ...args) {
+      if (format === undefined) {
+        throw new Error(
+          '`warning(condition, format, ...args)` requires a warning ' +
+          'message argument'
+        );
+      }
+      if (!condition) {
+        printWarning(format, ...args);
+      }
+    }
+  : emptyFunction;
 
 module.exports = warning;


### PR DESCRIPTION
Enables the inlining of expressions like `var x = require('foo').x`, which can come from a) an `import {x} from 'foo'`, b) `const {x} = require('foo')` or c) `const foo = require('foo'); const x = foo.x`. This will enable further optimizations when detecting dead `require`s.

I simplified the plugin by making use of other Babel utilities, so that we don't have to manually track variables and scopes, and we equally treat all inlinable expressions. Also fixed a bug where `var foo = require('foo'), bar = require('bar')` was not properly getting inlined.

Added tests to ensure that new cases are covered, made sure all existing ones still pass.