### PR TITLE
Inline requires on exit

### DIFF
--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -65,27 +65,14 @@ describe('inline-requires', function() {
     ]);
   });
 
-  it('should throw when assigning to a require', function() {
-    expect(function() {
-      transform([
-        'var foo = require("foo");',
-        'foo = "bar";',
-      ]);
-    }).toThrow(ReferenceError);
-
-    expect(function() {
-      transform([
-        'var foo = require("foo");',
-        'foo = "bar";',
-      ]);
-    }).toThrow(/\bline: 2\b/);
-
-    expect(function() {
-      transform([
-        'var foo = require("foo");',
-        'foo = "bar";',
-      ]);
-    }).toThrow(/\bname: foo\b/);
+  it('should avoid inlining when re-assigning to a require', function() {
+    compare([
+      'var foo = require("foo");',
+      'foo = "bar";',
+    ], [
+      'var foo = require("foo");',
+      'foo = "bar";',
+    ]);
   });
 
   it('should properly handle identifiers declared before their corresponding require statement', function() {


### PR DESCRIPTION
Make sure the inliner executes on exit, so that all the changes that have happened with intermediate syntax (e.g. JSX) and values (e.g. other plugins) are fully set.

Also, when a `require` gets redefined, avoid inlining it. This can legitimately happen when using generic helpers like `emptyObject` or `emptyFunction`.
