### PR TITLE
Remove location when cloning "require" calls

### DIFF
--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -133,27 +133,32 @@ describe('inline-requires', function() {
       '};',
     ]);
   });
+
+  it('should remove loc information from nodes', function() {
+    var ast = transform(['var x = require("x"); x']).ast;
+    var expression = ast.program.body[0].expression;
+
+    function noLoc(node) {
+      expect(node.start).toBeUndefined();
+      expect(node.end).toBeUndefined();
+      expect(node.loc).toBeUndefined();
+    }
+
+    noLoc(expression);
+    noLoc(expression.arguments[0]);
+  });
 });
 
 function transform(input) {
-  return babel.transform(normalise(input), {
+  return babel.transform(input.join('\n'), {
+    compact: true,
     plugins: [
       [require('babel-plugin-transform-es2015-modules-commonjs'), {strict: false}],
       require('../inline-requires.js')
     ],
-  }).code;
-}
-
-function normalise(input) {
-  return Array.isArray(input) ? input.join('\n') : input;
+  });
 }
 
 function compare(input, output) {
-  var compiled = transform(input);
-  output = normalise(output);
-  expect(strip(compiled)).toEqual(strip(output));
-}
-
-function strip(input) {
-  return input.trim().replace(/\n\n/g, '\n');
+  expect(transform(input).code).toBe(transform(output).code);
 }


### PR DESCRIPTION
Due to the fact that the same `require` call is getting inlined multiple times, the Chrome Developer Tool is showing multiple breakpoints at the requires. While this is _technically_ correct, it creates confusion, so we'll remove all location data from the node that will be moved.

Tests were added to ensure the behavior is correct.