### PR TITLE
Add the ability of inlining any call

### DIFF
--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -134,6 +134,21 @@ describe('inline-requires', function() {
     ]);
   });
 
+  it('should inline the given method calls', function() {
+    compare([
+      'const inlinedCustom = customStuff("foo");',
+      'const inlinedRequire = require("bar");',
+      '',
+      'inlinedCustom();',
+      'inlinedRequire();',
+    ], [
+      'customStuff("foo")();',
+      'require("bar")();',
+    ], {
+      inlineableCalls: ['customStuff'],
+    });
+  });
+
   it('should remove loc information from nodes', function() {
     var ast = transform(['var x = require("x"); x']).ast;
     var expression = ast.program.body[0].expression;
@@ -149,16 +164,16 @@ describe('inline-requires', function() {
   });
 });
 
-function transform(input) {
+function transform(input, opts) {
   return babel.transform(input.join('\n'), {
     compact: true,
     plugins: [
       [require('babel-plugin-transform-es2015-modules-commonjs'), {strict: false}],
-      require('../inline-requires.js')
+      [require('../inline-requires.js'), opts],
     ],
   });
 }
 
-function compare(input, output) {
-  expect(transform(input).code).toBe(transform(output).code);
+function compare(input, output, opts) {
+  expect(transform(input, opts).code).toBe(transform(output, opts).code);
 }


### PR DESCRIPTION
_Note: this PR is based in #301, which needs to be reviewed before reviewing this one._

Adds the ability of customizing the name of the calls that can be inlined. By default, this list is only composed by `require`. A test has been added to demonstrate the behavior.