### PR TITLE
fix: allow babel-eslint 9 and eslint 5

### DIFF
--- a/packages/eslint-config-fbjs/package.json
+++ b/packages/eslint-config-fbjs/package.json
@@ -19,8 +19,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "babel-eslint": "^7.2.3 || ^8.0.0",
-    "eslint": "^4.2.0",
+    "babel-eslint": "^7.2.3 || ^8.0.0 || ^9.0.0",
+    "eslint": "^4.2.0 || ^5.0.0",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",

--- a/packages/eslint-config-fbjs/package.json
+++ b/packages/eslint-config-fbjs/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "babel-eslint": "^7.2.3 || ^8.0.0 || ^9.0.0",
     "eslint": "^4.2.0 || ^5.0.0",
-    "eslint-plugin-babel": "^4.1.1",
+    "eslint-plugin-babel": "^4.1.1 || ^5.0.0",
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.1.0",


### PR DESCRIPTION
No breaking changes from the perspective of this package