### PR TITLE
Fix fbjs-scripts dependency on babel-preset-fbjs

### DIFF
--- a/packages/fbjs-scripts/package.json
+++ b/packages/fbjs-scripts/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@babel/core": "^7.0.0",
     "ansi-colors": "^1.0.1",
-    "babel-preset-fbjs": "file:../babel-preset-fbjs",
+    "babel-preset-fbjs": "^3.0.0",
     "core-js": "^2.4.1",
     "cross-spawn": "^5.1.0",
     "fancy-log": "^1.3.2",

--- a/packages/fbjs-scripts/yarn.lock
+++ b/packages/fbjs-scripts/yarn.lock
@@ -432,8 +432,9 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   version "7.0.0-beta.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
 
-"babel-preset-fbjs@file:../babel-preset-fbjs":
-  version "2.2.0"
+babel-preset-fbjs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.0.0.tgz#97878499b1e264d30bfe75b43b6e4138a914e5a1"
   dependencies:
     "@babel/plugin-check-constants" "^7.0.0-beta.38"
     "@babel/plugin-proposal-class-properties" "^7.0.0"

--- a/packages/fbjs/yarn.lock
+++ b/packages/fbjs/yarn.lock
@@ -674,8 +674,8 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   version "7.0.0-beta.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
 
-"babel-preset-fbjs@file:../babel-preset-fbjs":
-  version "2.2.0"
+babel-preset-fbjs@^3.0.0, "babel-preset-fbjs@file:../babel-preset-fbjs":
+  version "3.0.0"
   dependencies:
     "@babel/plugin-check-constants" "^7.0.0-beta.38"
     "@babel/plugin-proposal-class-properties" "^7.0.0"
@@ -1331,11 +1331,11 @@ fbjs-css-vars@^1.0.0:
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.1.tgz#836d876e887d702f45610f5ebd2fbeef649527fc"
 
 "fbjs-scripts@file:../fbjs-scripts":
-  version "0.8.3"
+  version "1.0.1"
   dependencies:
     "@babel/core" "^7.0.0"
     ansi-colors "^1.0.1"
-    babel-preset-fbjs "file:../../../Library/Caches/Yarn/v1/babel-preset-fbjs"
+    babel-preset-fbjs "^3.0.0"
     core-js "^2.4.1"
     cross-spawn "^5.1.0"
     fancy-log "^1.3.2"


### PR DESCRIPTION
#303 accidentally changed the dependency `fbjs-scripts` had on `babel-preset-fbjs` to be a relative file path. This breaks when installing `fbjs-scripts` from npm.

This commit fixes that