### PR TITLE
In Babel 7, a preset should always export a function by default

### DIFF
--- a/packages/babel-preset-fbjs/index.js
+++ b/packages/babel-preset-fbjs/index.js
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-module.exports = require('./configure')({});
+module.exports = require('./configure');


### PR DESCRIPTION
When running babel-preset-env ^3.0.0, I'm running into the following error:

```
Plugin/Preset files are not allowed to export objects, only functions. In /Users/jstejada/relay/node_modules/babel-preset-fbjs/index.js
```

This PR makes it so `babel-preset-env` exports the configure function by default