### PR TITLE
Refactor inline-requires tests w/ babel-plugin-tester

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,12 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+'use strict';
+
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'all',
+  bracketSpacing: false,
+  jsxBracketSameLine: true,
+  parser: 'flow',
+  requirePragma: true,
+};

--- a/packages/babel-preset-fbjs/package.json
+++ b/packages/babel-preset-fbjs/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
+    "babel-plugin-tester": "^5.5.1",
     "jest-cli": "^23.6.0"
   }
 }

--- a/packages/babel-preset-fbjs/plugins/__tests__/__snapshots__/inline-requires-test.js.snap
+++ b/packages/babel-preset-fbjs/plugins/__tests__/__snapshots__/inline-requires-test.js.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`inline-requires delete unused requires: delete unused requires 1`] = `
+"
+var foo = require(\\"foo\\");
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+
+"
+`;
+
+exports[`inline-requires inlines any number of variable declarations: inlines any number of variable declarations 1`] = `
+"
+var foo = require(\\"foo\\"), bar = require(\\"bar\\"), baz = 4;
+foo.method()
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var baz = 4;
+require(\\"foo\\").method();
+"
+`;
+
+exports[`inline-requires inlines destructured require properties: inlines destructured require properties 1`] = `
+"
+var tmp = require(\\"./a\\");
+var a = tmp.a
+var D = {
+  b: function(c) { c ? a(c.toString()) : a(\\"No c!\\"); },
+};
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var D = {
+  b: function (c) {
+    c ? require(\\"./a\\").a(c.toString()) : require(\\"./a\\").a(\\"No c!\\");
+  }
+};
+"
+`;
+
+exports[`inline-requires inlines functions provided via \`inlineableCalls\`: inlines functions provided via \`inlineableCalls\` 1`] = `
+"
+const inlinedCustom = customStuff(\\"foo\\");
+const inlinedRequire = require(\\"bar\\");
+
+inlinedCustom();
+inlinedRequire();
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+customStuff(\\"foo\\")();
+require(\\"bar\\")();
+"
+`;
+
+exports[`inline-requires inlines multiple usages: inlines multiple usages 1`] = `
+"
+var foo = require(\\"foo\\");
+foo.bar()
+foo.baz()
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+require(\\"foo\\").bar();
+require(\\"foo\\").baz();
+"
+`;
+
+exports[`inline-requires inlines requires that are referenced before the require statement: inlines requires that are referenced before the require statement 1`] = `
+"
+function foo() {
+  bar();
+}
+var bar = require(\\"baz\\");
+foo();
+bar();
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+function foo() {
+  require(\\"baz\\")();
+}
+
+foo();
+require(\\"baz\\")();
+"
+`;
+
+exports[`inline-requires inlines single usage: inlines single usage 1`] = `
+"
+var foo = require(\\"foo\\");
+foo.bar()
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+require(\\"foo\\").bar();
+"
+`;

--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -1,180 +1,151 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @format
  */
 
 'use strict';
 
-jest.autoMockOff();
+const babel = require('@babel/core');
+const inlineRequiresPlugin = require('../inline-requires');
+const pluginTester = require('babel-plugin-tester');
 
-var babel = require('@babel/core');
+pluginTester({
+  plugin: inlineRequiresPlugin,
+  pluginName: 'inline-requires',
+  pluginOptions: {
+    inlineableCalls: ['customStuff'],
+  },
+  tests: {
+    'inlines single usage': {
+      code: ['var foo = require("foo");', 'foo.bar()'].join('\n'),
+      snapshot: true,
+    },
 
-describe('inline-requires', function() {
-  it('should inline single usage', function() {
-    compare([
-      'var foo = require("foo");',
-      'foo.bar()',
-    ], [
-      'require("foo").bar();',
-    ]);
-  });
+    'inlines multiple usages': {
+      code: ['var foo = require("foo");', 'foo.bar()', 'foo.baz()'].join('\n'),
+      snapshot: true,
+    },
 
-  it('should inline multiple usage', function() {
-    compare([
-      'var foo = require("foo");',
-      'foo.bar()',
-      'foo.baz()',
-    ], [
-      'require("foo").bar();',
-      'require("foo").baz();',
-    ]);
-  });
+    'inlines any number of variable declarations': {
+      code: [
+        'var foo = require("foo"), bar = require("bar"), baz = 4;',
+        'foo.method()',
+      ].join('\n'),
+      snapshot: true,
+    },
 
-  it('should not matter the variable declaration length', function() {
-    compare([
-      'var foo = require("foo"), bar = require("bar"), baz = 4;',
-      'foo.method()',
-    ], [
-      'var baz = 4;',
-      'require("foo").method();',
-    ]);
+    'ignores requires that are not assigned': {
+      code: ['require("foo");'].join('\n'),
+      snapshot: false,
+    },
 
-    compare([
-      'var foo = require("foo"), bar = require("bar");',
-      'foo.method()',
-    ], [
-      'require("foo").method();',
-    ]);
-  });
+    'delete unused requires': {
+      code: ['var foo = require("foo");'].join('\n'),
+      snapshot: true,
+    },
 
-  it('should inline requires that are not assigned', function() {
-    compare([
-      'require("foo");',
-    ], [
-      'require("foo");',
-    ]);
-  });
+    'ignores requires that are re-assigned': {
+      code: ['var foo = require("foo");', 'foo = "bar";'].join('\n'),
+      snapshot: false,
+    },
 
-  it('should delete unused requires', function() {
-    compare([
-      'var foo = require("foo");',
-    ], [
-      '',
-    ]);
-  });
+    'inlines requires that are referenced before the require statement': {
+      code: [
+        'function foo() {',
+        '  bar();',
+        '}',
+        'var bar = require("baz");',
+        'foo();',
+        'bar();',
+      ].join('\n'),
+      snapshot: true,
+    },
 
-  it('should avoid inlining when re-assigning to a require', function() {
-    compare([
-      'var foo = require("foo");',
-      'foo = "bar";',
-    ], [
-      'var foo = require("foo");',
-      'foo = "bar";',
-    ]);
-  });
+    'inlines destructured require properties': {
+      code: [
+        'var tmp = require("./a");',
+        'var a = tmp.a',
+        'var D = {',
+        '  b: function(c) { c ? a(c.toString()) : a("No c!"); },',
+        '};',
+      ].join('\n'),
+      snapshot: true,
+    },
 
-  it('should properly handle identifiers declared before their corresponding require statement', function() {
-    compare([
-      'function foo() {',
-      '  bar();',
-      '}',
-      'var bar = require("baz");',
-      'foo();',
-      'bar();',
-    ], [
-      'function foo() {',
-      '  require("baz")();',
-      '}',
-      'foo();',
-      'require("baz")();',
-    ]);
-  });
+    'inlines functions provided via `inlineableCalls`': {
+      code: [
+        'const inlinedCustom = customStuff("foo");',
+        'const inlinedRequire = require("bar");',
+        '',
+        'inlinedCustom();',
+        'inlinedRequire();',
+      ].join('\n'),
+      snapshot: true,
+    },
+  },
+});
 
-  it('should be compatible with destructuring', function() {
-    compare([
-      'var tmp = require("./a");',
-      'var a = tmp.a',
-      'var D = {',
-      '  b: function(c) { c ? a(c.toString()) : a("No c!"); },',
-      '};',
-    ], [
-      'var D = {',
-      '  b: function (c) {',
-      '    c ? require("./a").a(c.toString()) : require("./a").a("No c!");',
-      '  }',
-      '};',
-    ]);
-  });
+describe('inline-requires', () => {
+  const transform = (source, options) =>
+    babel.transform(source.join('\n'), {
+      ast: true,
+      compact: true,
+      plugins: [
+        [require('@babel/plugin-transform-modules-commonjs'), {strict: false}],
+        [inlineRequiresPlugin, options],
+      ],
+    });
+
+  const compare = (input, output, options) => {
+    expect(transform(input, options).code).toBe(
+      transform(output, options).code,
+    );
+  };
 
   it('should be compatible with other transforms like transform-modules-commonjs', function() {
-    compare([
-      'import Imported from "foo";',
-      'console.log(Imported);',
-    ], [
-      'var _foo = _interopRequireDefault(require("foo"));',
-      'function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }',
-      'console.log(_foo.default);',
-    ]);
+    compare(
+      ['import Imported from "foo";', 'console.log(Imported);'],
+      [
+        'var _foo = _interopRequireDefault(require("foo"));',
+        'function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }',
+        'console.log(_foo.default);',
+      ],
+    );
   });
 
   it('should be compatible with `transform-modules-commonjs` when using named imports', function() {
-    compare([
-      'import {a} from "./a";',
-      'var D = {',
-      '  b: function(c) { c ? a(c.toString()) : a("No c!"); },',
-      '};',
-    ], [
-      'var D = {',
-      '  b: function (c) {',
-      '    c ? (0, require("./a").a)(c.toString()) : (0, require("./a").a)("No c!");',
-      '  }',
-      '};',
-    ]);
-  });
-
-  it('should inline the given method calls', function() {
-    compare([
-      'const inlinedCustom = customStuff("foo");',
-      'const inlinedRequire = require("bar");',
-      '',
-      'inlinedCustom();',
-      'inlinedRequire();',
-    ], [
-      'customStuff("foo")();',
-      'require("bar")();',
-    ], {
-      inlineableCalls: ['customStuff'],
-    });
+    compare(
+      [
+        'import {a} from "./a";',
+        'var D = {',
+        '  b: function(c) { c ? a(c.toString()) : a("No c!"); },',
+        '};',
+      ],
+      [
+        'var D = {',
+        '  b: function (c) {',
+        '    c ? (0, require("./a").a)(c.toString()) : (0, require("./a").a)("No c!");',
+        '  }',
+        '};',
+      ],
+    );
   });
 
   it('should remove loc information from nodes', function() {
-    var ast = transform(['var x = require("x"); x']).ast;
-    var expression = ast.program.body[0].expression;
+    const ast = transform(['var x = require("x"); x']).ast;
+    const expression = ast.program.body[0].expression;
 
-    function noLoc(node) {
+    function expectNoLocation(node) {
       expect(node.start).toBeUndefined();
       expect(node.end).toBeUndefined();
       expect(node.loc).toBeUndefined();
     }
 
-    noLoc(expression);
-    noLoc(expression.arguments[0]);
+    expectNoLocation(expression);
+    expectNoLocation(expression.arguments[0]);
   });
 });
-
-function transform(input, opts) {
-  return babel.transform(input.join('\n'), {
-    ast: true,
-    compact: true,
-    plugins: [
-      [require('@babel/plugin-transform-modules-commonjs'), {strict: false}],
-      [require('../inline-requires.js'), opts],
-    ],
-  });
-}
-
-function compare(input, output, opts) {
-  expect(transform(input, opts).code).toBe(transform(output, opts).code);
-}

--- a/packages/babel-preset-fbjs/yarn.lock
+++ b/packages/babel-preset-fbjs/yarn.lock
@@ -723,6 +723,17 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
+babel-plugin-tester@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-tester/-/babel-plugin-tester-5.5.1.tgz#93648d140e67a81fa8474a73d3382b4fd8e91ca6"
+  integrity sha512-/Sc90Bv2aHGglPkM2Ezw9w/bKMk39h+Dj7G5+Qc9SM2sarnojQhe3NWwZG7cByCXWbp86Gqh4VoYj1YCERFpSg==
+  dependencies:
+    common-tags "^1.4.0"
+    invariant "^2.2.2"
+    lodash.merge "^4.6.0"
+    path-exists "^3.0.0"
+    strip-indent "^2.0.0"
+
 babel-preset-jest@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
@@ -1007,6 +1018,11 @@ commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
+
+common-tags@^1.4.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
+  integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -2556,6 +2572,11 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.merge@^4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
+  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -3669,6 +3690,11 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Refactors the Jest test for `inline-requires` to use `babel-plugin-tester`.