### PR TITLE
fix: update dated peer deps in eslint config

### DIFF
--- a/packages/eslint-config-fbjs/package.json
+++ b/packages/eslint-config-fbjs/package.json
@@ -19,12 +19,12 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "babel-eslint": "^7.2.3 || ^8.0.0 || ^9.0.0",
+    "babel-eslint": "^7.2.3 || ^8.0.0 || ^9.0.0 || ^10.0.0",
     "eslint": "^4.2.0 || ^5.0.0",
     "eslint-plugin-babel": "^4.1.1 || ^5.0.0",
-    "eslint-plugin-flowtype": "^2.35.0",
+    "eslint-plugin-flowtype": "^2.35.0 || ^3.0.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.1.0",
-    "eslint-plugin-relay": "~0.0.8"
+    "eslint-plugin-relay": "~0.0.8 || ^1.0.0""
   }
 }


### PR DESCRIPTION
I wanna bump these in Jest.

(note that a new major of `babel-eslint` is coming any day now as well)