### PR TITLE
[eslint-config-fbjs] remove relay dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.1.0",
-    "eslint-plugin-relay": "0.0.8",
     "prettier": "^1.14.3"
   },
   "scripts": {

--- a/packages/eslint-config-fbjs/CHANGELOG.md
+++ b/packages/eslint-config-fbjs/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [master]
+
+### Removed
+- Removed peer dependency of `eslint-plugin-relay`.
+
 ## [2.0.1] - 2017-11-26
 
 ### Changed

--- a/packages/eslint-config-fbjs/README.md
+++ b/packages/eslint-config-fbjs/README.md
@@ -19,7 +19,6 @@ npm install --save-dev \
   eslint-plugin-flowtype \
   eslint-plugin-jsx-a11y \
   eslint-plugin-react \
-  eslint-plugin-relay \
   eslint \
   babel-eslint
 ```
@@ -32,7 +31,6 @@ yarn add --dev \
   eslint-plugin-flowtype \
   eslint-plugin-jsx-a11y \
   eslint-plugin-react \
-  eslint-plugin-relay \
   eslint \
   babel-eslint
 ```

--- a/packages/eslint-config-fbjs/index.js
+++ b/packages/eslint-config-fbjs/index.js
@@ -45,7 +45,6 @@ function getBaseConfig() {
       'flowtype',
       'jsx-a11y',
       'react',
-      'relay',
     ],
 
     // Tries to match the jshint configuration as closely as possible, with the
@@ -557,11 +556,6 @@ function getBaseConfig() {
       // annotations.
       'flowtype/define-flow-type': WARNING,
       'flowtype/use-flow-type': WARNING,
-
-
-      'relay/graphql-syntax': ERROR,
-      'relay/graphql-naming': ERROR,
-      'relay/compat-uses-vars': WARNING,
     },
 
     // Defines a basic set of globals

--- a/packages/eslint-config-fbjs/package.json
+++ b/packages/eslint-config-fbjs/package.json
@@ -24,7 +24,6 @@
     "eslint-plugin-babel": "^4.1.1 || ^5.0.0",
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
-    "eslint-plugin-react": "^7.1.0",
-    "eslint-plugin-relay": "~0.0.8"
+    "eslint-plugin-react": "^7.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,13 +428,6 @@ eslint-plugin-react@^7.1.0:
     jsx-ast-utils "^2.0.1"
     prop-types "^15.6.2"
 
-eslint-plugin-relay@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-relay/-/eslint-plugin-relay-0.0.8.tgz#68d99f9fdc518a146bb8aee7519538aa56528dc8"
-  integrity sha1-aNmfn9xRihRruK7nUZU4qlZSjcg=
-  dependencies:
-    graphql "^0.10.1"
-
 eslint-scope@^3.7.1:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
@@ -632,13 +625,6 @@ graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
-graphql@^0.10.1:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.5.tgz#c9be17ca2bdfdbd134077ffd9bbaa48b8becd298"
-  integrity sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==
-  dependencies:
-    iterall "^1.1.0"
-
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -780,11 +766,6 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
-
-iterall@^1.1.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
-  integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
The Relay eslint plugin is intended for product code, I don't think
it makes sense to pull in (likely outdated) GraphQL dependencies into
the framework projects using the fbjs eslint config.