### PR TITLE
Install latest yarn on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ env:
   - CMD=preset:test
   - CMD=signedsource:test
 script: yarn run $CMD
+before_install:
+  # Install latest yarn (will go to ~/.yarn) and update $PATH for current shell
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"


### PR DESCRIPTION
#332 is failing because Travis has an old version of Yarn (v1.3.2) installed. Output format has changed at some point (but semver?) so let's just make sure we're always running the latest.