### PR TITLE
Include "require.resolve" of a "require" as an inlineable call

### DIFF
--- a/packages/babel-preset-fbjs/plugins/__tests__/__snapshots__/inline-requires-test.js.snap
+++ b/packages/babel-preset-fbjs/plugins/__tests__/__snapshots__/inline-requires-test.js.snap
@@ -110,3 +110,15 @@ foo.bar()
 require(\\"foo\\").bar();
 "
 `;
+
+exports[`inline-requires inlines with multiple arguments: inlines with multiple arguments 1`] = `
+"
+const a = require(\\"Foo\\", \\"Bar\\", 47);
+
+a();
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+require(\\"Foo\\", \\"Bar\\", 47)();
+"
+`;

--- a/packages/babel-preset-fbjs/plugins/__tests__/__snapshots__/inline-requires-test.js.snap
+++ b/packages/babel-preset-fbjs/plugins/__tests__/__snapshots__/inline-requires-test.js.snap
@@ -68,6 +68,18 @@ require(\\"foo\\").baz();
 "
 `;
 
+exports[`inline-requires inlines require.resolve calls: inlines require.resolve calls 1`] = `
+"
+const a = require(require.resolve(\\"Foo\\")).bar;
+
+a();
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+require(require.resolve(\\"Foo\\")).bar();
+"
+`;
+
 exports[`inline-requires inlines requires that are referenced before the require statement: inlines requires that are referenced before the require statement 1`] = `
 "
 function foo() {

--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -114,6 +114,15 @@ pluginTester({
       ].join('\n'),
       snapshot: true,
     },
+
+    'inlines with multiple arguments': {
+      code: [
+        'const a = require("Foo", "Bar", 47);',
+        '',
+        'a();',
+      ].join('\n'),
+      snapshot: true,
+    },
   },
 });
 

--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -105,6 +105,15 @@ pluginTester({
       ].join('\n'),
       snapshot: false,
     },
+
+    'inlines require.resolve calls': {
+      code: [
+        'const a = require(require.resolve("Foo")).bar;',
+        '',
+        'a();',
+      ].join('\n'),
+      snapshot: true,
+    },
   },
 });
 

--- a/packages/babel-preset-fbjs/plugins/inline-requires.js
+++ b/packages/babel-preset-fbjs/plugins/inline-requires.js
@@ -160,9 +160,10 @@ function isInlineableCall(node, state) {
     node['arguments'][0].type === 'CallExpression' &&
     node['arguments'][0].callee.type === 'MemberExpression' &&
     node['arguments'][0].callee.object.type === 'Identifier' &&
-    node['arguments'][0].callee.object.name === 'require' &&
+    state.inlineableCalls.hasOwnProperty(node['arguments'][0].callee.object.name) &&
     node['arguments'][0].callee.property.type === 'Identifier' &&
     node['arguments'][0].callee.property.name === 'resolve' &&
+    node['arguments'][0]['arguments'].length >= 1 &&
     node['arguments'][0]['arguments'][0].type === 'StringLiteral' &&
     !state.ignoredRequires.hasOwnProperty(node['arguments'][0]['arguments'][0].value);
 

--- a/packages/babel-preset-fbjs/plugins/inline-requires.js
+++ b/packages/babel-preset-fbjs/plugins/inline-requires.js
@@ -142,12 +142,29 @@ function inlineableMemberAlias(path, state) {
 }
 
 function isInlineableCall(node, state) {
-  return (
+  const isInlineable =
     node.type === 'CallExpression' &&
     node.callee.type === 'Identifier' &&
     state.inlineableCalls.hasOwnProperty(node.callee.name) &&
-    node['arguments'].length === 1 &&
+    node['arguments'].length >= 1;
+
+  // require('foo');
+  const isStandardCall =
+    isInlineable &&
     node['arguments'][0].type === 'StringLiteral' &&
-    !state.ignoredRequires.hasOwnProperty(node['arguments'][0].value)
-  );
+    !state.ignoredRequires.hasOwnProperty(node['arguments'][0].value);
+
+  // require(require.resolve('foo'));
+  const isRequireResolveCall =
+    isInlineable &&
+    node['arguments'][0].type === 'CallExpression' &&
+    node['arguments'][0].callee.type === 'MemberExpression' &&
+    node['arguments'][0].callee.object.type === 'Identifier' &&
+    node['arguments'][0].callee.object.name === 'require' &&
+    node['arguments'][0].callee.property.type === 'Identifier' &&
+    node['arguments'][0].callee.property.name === 'resolve' &&
+    node['arguments'][0]['arguments'][0].type === 'StringLiteral' &&
+    !state.ignoredRequires.hasOwnProperty(node['arguments'][0]['arguments'][0].value);
+
+  return isStandardCall || isRequireResolveCall;
 }


### PR DESCRIPTION
In tests we sometimes use `require(require.resolve('module'))`, which is the same as `require('module')`, so we add an additional case to be sure both are inlined. Also added tests to verify the behavior.