### PR TITLE
Remove rootDir from jest transformer cache key

### DIFF
--- a/packages/fbjs-scripts/CHANGELOG.md
+++ b/packages/fbjs-scripts/CHANGELOG.md
@@ -1,3 +1,21 @@
+## master
+
+### Changed
+- Removed `rootDir`, if available, from `createCacheKeyFunction`.
+
+
+## [1.0.1]
+
+### Fixed
+- Fixed `babel-preset-fbjs` dependency
+
+
+## [1.0.0] - 2018-09-18
+
+### Changed
+- Migrated to Babel 7
+
+
 ## [0.8.3] - 2018-04-18
 
 ### Changed

--- a/packages/fbjs-scripts/jest/createCacheKeyFunction.js
+++ b/packages/fbjs-scripts/jest/createCacheKeyFunction.js
@@ -9,23 +9,45 @@
 
 const crypto = require('crypto');
 const fs = require('fs');
+const path = require('path');
 
-function buildCacheKey(files, base) {
-  return files.reduce(
-    (src, fileName) => src + fs.readFileSync(fileName),
-    base
-  );
+function getGlobalCacheKey(files, values) {
+  const presetVersion = require('../package').dependencies['babel-preset-fbjs'];
+
+  const chunks = [
+    process.env.NODE_ENV,
+    process.env.BABEL_ENV,
+    presetVersion,
+    ...values,
+    ...files.map(file => fs.readFileSync(file)),
+  ];
+
+  return chunks
+    .reduce(
+      (hash, chunk) => hash.update('\0', 'utf-8').update(chunk || ''),
+      crypto.createHash('md5'),
+    )
+    .digest('hex');
 }
 
-module.exports = files => {
-  const presetVersion = require('../package').dependencies['babel-preset-fbjs'];
-  const cacheKey = buildCacheKey(files, presetVersion);
+function getCacheKeyFunction(globalCacheKey) {
   return (src, file, configString, options) => {
+    const {instrument, config} = options;
+    const rootDir = config && config.rootDir;
+
     return crypto
       .createHash('md5')
-      .update(cacheKey)
-      .update(src + file + configString)
-      .update(options && options.instrument ? 'instrument' : '')
+      .update(globalCacheKey)
+      .update('\0', 'utf8')
+      .update(src)
+      .update('\0', 'utf8')
+      .update(rootDir ? path.relative(config.rootDir, file) : '')
+      .update('\0', 'utf8')
+      .update(instrument ? 'instrument' : '')
       .digest('hex');
   };
+}
+
+module.exports = (files = [], values = []) => {
+  return getCacheKeyFunction(getGlobalCacheKey(files, values));
 };

--- a/packages/fbjs-scripts/jest/createCacheKeyFunction.js
+++ b/packages/fbjs-scripts/jest/createCacheKeyFunction.js
@@ -25,7 +25,7 @@ function getGlobalCacheKey(files, values) {
   return chunks
     .reduce(
       (hash, chunk) => hash.update('\0', 'utf-8').update(chunk || ''),
-      crypto.createHash('md5'),
+      crypto.createHash('md5')
     )
     .digest('hex');
 }


### PR DESCRIPTION
This modifies the `createCacheKeyFunction` module to allow:
1. Passing custom values to take into account for the global cache breaker (no only files).
2. Ignoring the `rootDir` option of the Jest project so it enables remote caching.

I also added some missing entries in the changelog.

This has been tested in fbsource.