### PR TITLE
Update Flow and fix emptyFunction type

### DIFF
--- a/packages/fbjs/package.json
+++ b/packages/fbjs/package.json
@@ -19,7 +19,7 @@
     "babel-preset-fbjs": "file:../babel-preset-fbjs",
     "del": "^2.2.0",
     "fbjs-scripts": "file:../fbjs-scripts",
-    "flow-bin": "^0.95.0",
+    "flow-bin": "^0.99.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^8.0.0",
     "gulp-flatten": "^0.2.0",

--- a/packages/fbjs/src/.flowconfig
+++ b/packages/fbjs/src/.flowconfig
@@ -11,4 +11,4 @@
 module.system=haste
 
 [version]
-^0.95.0
+^0.99.0

--- a/packages/fbjs/src/core/emptyFunction.js
+++ b/packages/fbjs/src/core/emptyFunction.js
@@ -8,6 +8,18 @@
  * @flow
  */
 
+export type FunctionReturning<+T> = (...args: $ReadOnlyArray<mixed>) => T;
+
+export type EmptyFunctionType = {
+  (...args: $ReadOnlyArray<mixed>): void,
+  thatReturns: <T>(x: T) => FunctionReturning<T>,
+  thatReturnsFalse: FunctionReturning<false>,
+  thatReturnsTrue: FunctionReturning<true>,
+  thatReturnsNull: FunctionReturning<null>,
+  thatReturnsThis: FunctionReturning<mixed>,
+  thatReturnsArgument: <T>(x: T) => T,
+};
+
 function makeEmptyFunction<T>(arg: T): (...args: Array<any>) => T {
   return function() {
     return arg;
@@ -19,7 +31,7 @@ function makeEmptyFunction<T>(arg: T): (...args: Array<any>) => T {
  * primarily useful idiomatically for overridable function endpoints which
  * always need to be callable, since JS lacks a null-call idiom ala Cocoa.
  */
-const emptyFunction: (...args: Array<any>) => void = function() {};
+const emptyFunction = function() {};
 
 emptyFunction.thatReturns = makeEmptyFunction;
 emptyFunction.thatReturnsFalse = makeEmptyFunction(false);
@@ -28,4 +40,4 @@ emptyFunction.thatReturnsNull = makeEmptyFunction(null);
 emptyFunction.thatReturnsThis = function() { return this; };
 emptyFunction.thatReturnsArgument = function(arg) { return arg; };
 
-module.exports = emptyFunction;
+module.exports = (emptyFunction: EmptyFunctionType);

--- a/packages/fbjs/yarn.lock
+++ b/packages/fbjs/yarn.lock
@@ -1629,7 +1629,7 @@ fbjs-css-vars@^1.0.0:
   integrity sha512-IM+v/C40MNZWqsLErc32e0TyIk/NhkkQZL0QmjBh6zi1eXv0/GeVKmKmueQX7nn9SXQBQbTUcB8zuexIF3/88w==
 
 "fbjs-scripts@file:../fbjs-scripts":
-  version "1.1.0"
+  version "1.2.0"
   dependencies:
     "@babel/core" "^7.0.0"
     ansi-colors "^1.0.1"
@@ -1727,10 +1727,10 @@ flagged-respawn@^1.0.0:
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.0.tgz#4e79ae9b2eb38bf86b3bb56bf3e0a56aa5fcabd7"
   integrity sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=
 
-flow-bin@^0.95.0:
-  version "0.95.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.95.1.tgz#633113831ccff4b7ee70a2730f63fc43b69ba85f"
-  integrity sha512-06IOC/pqPMNRYtC6AMZEWYR9Fi6UdBC7gImGinPuNUpPZFnP5E9/0cBCl3DWrH4zz/gSM2HdDilU7vPGpYIr2w==
+flow-bin@^0.99.0:
+  version "0.99.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.99.1.tgz#0d4f413ca84a3a95d0aa64214178684dd7c6a4c5"
+  integrity sha512-dipNwJlb4MsVt3IuDgPTymCNL4GFoq3pG+GbY6DmBbl0dJPWFSA383rCTmgbfFhoeJ1XCfYBan0BPryToSxiiQ==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Flow v0.99.0 is strict about function statics, which were previously typed as `any`. This added strictness causes issues for callers of the `emptyFunction` API involving static properties, like `emptyFunction.thatReturnsNull`.

This change updates the `emptyFunction` module to use a callable object type that also declares the types of the static properties. This might cause new Flow errors for library consumers.