### PR TITLE
Fix invariant function to throw error only if __DEV__ is true

### DIFF
--- a/packages/fbjs/src/__forks__/invariant.js
+++ b/packages/fbjs/src/__forks__/invariant.js
@@ -11,12 +11,12 @@
 'use strict';
 
 const validateFormat = __DEV__
-  ? function(format: mixed): void {}
-  : function(format: mixed): void {
+  ? function(format: mixed): void {
       if (format === undefined) {
         throw new Error('invariant(...): Second argument must be a string.');
       }
-    };
+    }
+  : function(format: mixed): void {};
 
 /**
  * Use invariant() to assert state which your program assumes to be true.


### PR DESCRIPTION
Related issue: https://github.com/facebook/fbjs/issues/347

A change was made in https://github.com/facebook/fbjs/pull/240/files that incorrectly flipped the logic to only throw an error if `__DEV__ === false`. This would change it back to only throw the error if `__DEV__ === true` as was the behaviour previously.

