### PR TITLE
fix: allow eslint v6 as peer dependency

### DIFF
--- a/packages/eslint-config-fbjs-opensource/package.json
+++ b/packages/eslint-config-fbjs-opensource/package.json
@@ -23,6 +23,6 @@
     "fbjs-eslint-utils": "^1.0.0"
   },
   "peerDependencies": {
-    "eslint": "^5.1.0"
+    "eslint": "^5.1.0 || ^6.0.0"
   }
 }

--- a/packages/eslint-config-fbjs/package.json
+++ b/packages/eslint-config-fbjs/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "babel-eslint": "^8.0.0 || ^9.0.0 || ^10.0.0",
-    "eslint": "^5.1.0",
+    "eslint": "^5.1.0 || ^6.0.0",
     "eslint-plugin-babel": "^4.1.1 || ^5.2.1",
     "eslint-plugin-flowtype": "^2.43.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",

--- a/packages/eslint-config-fbjs/package.json
+++ b/packages/eslint-config-fbjs/package.json
@@ -22,7 +22,7 @@
     "babel-eslint": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "eslint": "^5.1.0 || ^6.0.0",
     "eslint-plugin-babel": "^4.1.1 || ^5.2.1",
-    "eslint-plugin-flowtype": "^2.43.0",
+    "eslint-plugin-flowtype": "^2.43.0 || ^3.0.0 || ^4.0.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.6.1"
   }


### PR DESCRIPTION
Avoids a peer dep warning for Jest.

@cpojer something you can get landed and released?