### PR TITLE
update getByPathh.js

### DIFF
--- a/packages/fbjs/src/misc/getByPath.js
+++ b/packages/fbjs/src/misc/getByPath.js
@@ -42,7 +42,7 @@ function getByPath(
     const segment = path[i];
     // Use 'in' to check entire prototype chain since immutable js records
     // use prototypes
-    if (current && segment in current) {
+    if (typeof(current) == "object" && segment in current) {
       current = current[segment];
     } else {
       return fallbackValue;


### PR DESCRIPTION
if root = {a : {b : 123}} and path=["a","b","c"] previously available code would crash.

`Cannot use 'in' operator to search for 'c' in 123`