### PR TITLE
#314 - Fix isSigned being inverted. Add test for re-signing an existing file.

### DIFF
--- a/packages/signedsource/__tests__/signedsource-test.js
+++ b/packages/signedsource/__tests__/signedsource-test.js
@@ -19,6 +19,13 @@ test('signFile', () => {
   ).toEqual(
     `# @generated SignedSource<<4c0c1ae4f5863c72731b2f543e830fd5>>\ntest 2`
   );
+
+  // re-sign a file
+  expect(
+    SignedSource.signFile(`# @generated SignedSource<<eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee>>\nalready signed test`)
+  ).toEqual(
+    `# @generated SignedSource<<54e8ffafff15a19f858d95c9a13d5b1d>>\nalready signed test`
+  );
 });
 
 test('isSigned', () => {
@@ -27,9 +34,9 @@ test('isSigned', () => {
   );
 
   // Well, this is the opposite...
-  expect(SignedSource.isSigned(signedString)).toBe(false);
-  expect(SignedSource.isSigned(signedString + 'modified')).toBe(false);
-  expect(SignedSource.isSigned('unsigned')).toBe(true);
+  expect(SignedSource.isSigned(signedString)).toBe(true);
+  expect(SignedSource.isSigned(signedString + 'modified')).toBe(true);
+  expect(SignedSource.isSigned('unsigned')).toBe(false);
 });
 
 test('verifySignature', () => {

--- a/packages/signedsource/index.js
+++ b/packages/signedsource/index.js
@@ -54,7 +54,7 @@ const SignedSource = {
    * Checks whether a file is signed *without* verifying the signature.
    */
   isSigned(data) {
-    return !PATTERN.exec(data);
+    return PATTERN.exec(data) != null;
   },
 
   /**


### PR DESCRIPTION
The isSigned is inverted as #314 noted. Fixing that and updating tests. This allow now makes the re-signing of files with signFile to not fail. Adding a test for that too.