### PR TITLE
Fix runtime error in ErrorUtils.js

### DIFF
--- a/packages/fbjs/src/stubs/ErrorUtils.js
+++ b/packages/fbjs/src/stubs/ErrorUtils.js
@@ -9,7 +9,7 @@
 
 /* jslint unused:false */
 
-if (global.ErrorUtils) {
+if (typeof global !== 'undefined' && global.ErrorUtils) {
   module.exports = global.ErrorUtils;
 } else {
   var ErrorUtils = {


### PR DESCRIPTION
This file is used in [relay-runtime/store/RelayPublishQueue.js](https://github.com/facebook/relay/blob/v6.0.0/packages/relay-runtime/store/RelayPublishQueue.js#L13) and executed in browser where `global` object is not available which leads to a runtime error.