### PR TITLE
[fbjs][fbjs-scripts] Upgrade core-js version

### DIFF
--- a/packages/fbjs-scripts/jest/environment.js
+++ b/packages/fbjs-scripts/jest/environment.js
@@ -5,6 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-require('core-js/es6');
+require('core-js/es');
 
 global.__DEV__ = true;

--- a/packages/fbjs-scripts/package.json
+++ b/packages/fbjs-scripts/package.json
@@ -8,7 +8,7 @@
     "@babel/core": "^7.0.0",
     "ansi-colors": "^1.0.1",
     "babel-preset-fbjs": "^3.2.0",
-    "core-js": "^2.4.1",
+    "core-js": "^3.6.4",
     "cross-spawn": "^5.1.0",
     "fancy-log": "^1.3.2",
     "object-assign": "^4.0.1",

--- a/packages/fbjs-scripts/third-party-module-map.json
+++ b/packages/fbjs-scripts/third-party-module-map.json
@@ -1,6 +1,6 @@
 {
-  "core-js/library/es6/map": "core-js/library/es6/map",
-  "core-js/library/es6/set": "core-js/library/es6/set",
+  "core-js/es/map": "core-js/es/map",
+  "core-js/es/set": "core-js/es/set",
   "fbjs-css-vars": "fbjs-css-vars",
   "isomorphic-fetch": "isomorphic-fetch",
   "object-assign": "object-assign",

--- a/packages/fbjs-scripts/yarn.lock
+++ b/packages/fbjs-scripts/yarn.lock
@@ -555,10 +555,10 @@ convert-source-map@^1.1.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-core-js@^2.4.1:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
-  integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
+core-js@^3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
+  integrity sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==
 
 core-util-is@~1.0.0:
   version "1.0.2"

--- a/packages/fbjs/package.json
+++ b/packages/fbjs/package.json
@@ -63,7 +63,7 @@
     ]
   },
   "dependencies": {
-    "core-js": "^2.4.1",
+    "core-js": "^3.6.4",
     "fbjs-css-vars": "^1.0.0",
     "isomorphic-fetch": "^2.1.1",
     "loose-envify": "^1.0.0",

--- a/packages/fbjs/src/__forks__/Map.js
+++ b/packages/fbjs/src/__forks__/Map.js
@@ -7,4 +7,4 @@
  * @providesModule Map
  */
 
-module.exports = require('core-js/library/es6/map');
+module.exports = require('core-js/es/map');

--- a/packages/fbjs/src/__forks__/Set.js
+++ b/packages/fbjs/src/__forks__/Set.js
@@ -7,4 +7,4 @@
  * @providesModule Set
  */
 
-module.exports = require('core-js/library/es6/set');
+module.exports = require('core-js/es/set');

--- a/packages/fbjs/yarn.lock
+++ b/packages/fbjs/yarn.lock
@@ -1363,10 +1363,10 @@ core-js@^2.4.0, core-js@^2.5.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
-core-js@^2.4.1:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
-  integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
+core-js@^3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
+  integrity sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -1880,7 +1880,7 @@ fbjs-css-vars@^1.0.0:
     "@babel/core" "^7.0.0"
     ansi-colors "^1.0.1"
     babel-preset-fbjs "^3.2.0"
-    core-js "^2.4.1"
+    core-js "^3.6.4"
     cross-spawn "^5.1.0"
     fancy-log "^1.3.2"
     object-assign "^4.0.1"


### PR DESCRIPTION
Every time I use yarn I get a warning about how core-js < 3 is not supported for `relay` and `flux` through `fbjs`. This migrates `core-js` to version 3 for `fbjs` and `fbjs-scripts`.

@zpao please, you're my only hope