### PR TITLE
Replace isomorphic-fetch with cross-fetch

### DIFF
--- a/packages/fbjs-scripts/third-party-module-map.json
+++ b/packages/fbjs-scripts/third-party-module-map.json
@@ -1,6 +1,7 @@
 {
   "core-js/es/map": "core-js/es/map",
   "core-js/es/set": "core-js/es/set",
+  "cross-fetch": "cross-fetch",
   "fbjs-css-vars": "fbjs-css-vars",
   "isomorphic-fetch": "isomorphic-fetch",
   "object-assign": "object-assign",

--- a/packages/fbjs/package.json
+++ b/packages/fbjs/package.json
@@ -64,8 +64,8 @@
   },
   "dependencies": {
     "core-js": "^3.6.4",
+    "cross-fetch": "^3.0.4",
     "fbjs-css-vars": "^1.0.0",
-    "isomorphic-fetch": "^2.1.1",
     "loose-envify": "^1.0.0",
     "object-assign": "^4.1.0",
     "promise": "^7.1.1",

--- a/packages/fbjs/src/__forks__/__tests__/fetch-test.js
+++ b/packages/fbjs/src/__forks__/__tests__/fetch-test.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+jsinfra
+ */
+
+'use strict';
+
+jest.unmock('fetch');
+jest.mock('cross-fetch');
+
+const fetchImpl = require('cross-fetch');
+
+describe('fetch', function() {
+  afterEach(() => {
+    // Ensure the cached `fetch` module is cleared to test the other path.
+    jest.resetModules();
+  });
+
+  it('works with global fetch', () => {
+    const fetchMock = jest.fn();
+
+    global.fetch = fetchMock;
+    const fetch = require('fetch');
+    fetch();
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    delete global.fetch;
+  });
+
+  it('uses ponyfill without global fetch', () => {
+    // If node ever gets a global fetch, we'll start failing this case.
+    expect(global.fetch).toBeUndefined();
+
+    const fetch = require('fetch');
+    fetch();
+
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+});

--- a/packages/fbjs/src/__forks__/fetch.js
+++ b/packages/fbjs/src/__forks__/fetch.js
@@ -11,9 +11,9 @@
 
 // This hopefully supports the React Native case, which is already bringing along
 // its own fetch polyfill. That should exist on `global`. If that doesn't exist
-// then we'll try to polyfill, which might not work correctly in all environments.
+// then we'll try to ponyfill, which might not work correctly in all environments.
 if (global.fetch) {
   module.exports = global.fetch.bind(global);
 } else {
-  module.exports = require('isomorphic-fetch');
+  module.exports = require('cross-fetch');
 }

--- a/packages/fbjs/yarn.lock
+++ b/packages/fbjs/yarn.lock
@@ -1373,6 +1373,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cross-fetch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
+  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
+  dependencies:
+    node-fetch "2.6.0"
+    whatwg-fetch "3.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -1587,13 +1595,6 @@ emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
-
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.4"
@@ -2443,7 +2444,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -2763,7 +2764,7 @@ is-relative@^1.0.0:
   dependencies:
     is-unc-path "^1.0.0"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -2823,14 +2824,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -3696,13 +3689,10 @@ next-tick@~1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -5337,7 +5327,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.23"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==


### PR DESCRIPTION
cross-fetch seems to be a drop-in replacement for isomorphic-fetch, but
more actively maintained. I also added a test to ensure we maintain the
behavior of using global fetch if available (eg React-Native)
closes #363