### PR TITLE
Add entries for old core-js into module map

### DIFF
--- a/packages/fbjs-scripts/third-party-module-map.json
+++ b/packages/fbjs-scripts/third-party-module-map.json
@@ -1,6 +1,8 @@
 {
   "core-js/es/map": "core-js/es/map",
   "core-js/es/set": "core-js/es/set",
+  "core-js/library/es6/map": "core-js/library/es6/map",
+  "core-js/library/es6/set": "core-js/library/es6/set",
   "fbjs-css-vars": "fbjs-css-vars",
   "isomorphic-fetch": "isomorphic-fetch",
   "object-assign": "object-assign",


### PR DESCRIPTION
This will ensure users of fbjs-scripts keep the same old compat level
even if not updating fbjs.

Should have been left in there in #370.