### PR TITLE
Replace non-inclusive "whitelist" term with "allowlist"

### DIFF
--- a/packages/fbjs/src/functional/partitionObjectByKey.js
+++ b/packages/fbjs/src/functional/partitionObjectByKey.js
@@ -14,15 +14,15 @@ var partitionObject = require('partitionObject');
 
 /**
  * Partitions the enumerable properties of an object into two objects, given a
- * whitelist `Set` for the first object. This is comparable to
+ * allowlist `Set` for the first object. This is comparable to
  * `whitelistObjectKeys`, but eventually keeping all the keys. Returns a tuple
  * of objects `[first, second]`.
  */
 function partitionObjectByKey(
   source: Object,
-  whitelist: Set<string>
+  allowlist: Set<string>
 ): [Object, Object] {
-  return partitionObject(source, (_, key) => whitelist.has(key));
+  return partitionObject(source, (_, key) => allowlist.has(key));
 }
 
 module.exports = partitionObjectByKey;


### PR DESCRIPTION
Left out the reference to "whitelistObjectKeys" since I was unable to find it in this library so it looks like something that might be outside our control.