### PR TITLE
chore: move eslint-config-fb-strict into this repo

### DIFF
--- a/packages/eslint-config-fb-strict/index.js
+++ b/packages/eslint-config-fb-strict/index.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// Can't be ESModules as this is not compiled
+const fbjsConfig = require('eslint-config-fbjs');
+
+const variableNamePattern = String.raw`\s*[a-zA-Z_$][a-zA-Z_$\d]*\s*`;
+const importPattern =
+  String.raw`^(?:var|let|const|import type)\s+` +
+  '{?' +
+  variableNamePattern +
+  '(?:,' +
+  variableNamePattern +
+  ')*}?' +
+  String.raw`\s*(?:=\s*require\(|from)[a-zA-Z_+./''\s\d\-]+\)?[^;\n]*[;\n]`;
+const maxLenIgnorePattern = String.raw`(^\s*(it|test)\(|${importPattern})`;
+
+delete fbjsConfig.rules['babel/flow-object-type'];
+
+module.exports = Object.assign({}, fbjsConfig, {
+  env: {
+    es6: true,
+    'jest/globals': true,
+    node: true,
+  },
+  plugins: fbjsConfig.plugins.concat(['jest']),
+  rules: Object.assign({}, fbjsConfig.rules, {
+    'array-bracket-spacing': [2, 'never'],
+    'arrow-parens': [2, 'as-needed'],
+    'arrow-spacing': [2],
+    'brace-style': [
+      2,
+      '1tbs',
+      {
+        allowSingleLine: true,
+      },
+    ],
+    'comma-dangle': [2, 'always-multiline'],
+    'comma-spacing': [2],
+    'comma-style': [2, 'last'],
+    'computed-property-spacing': [2, 'never'],
+    'eol-last': [2],
+    'flowtype/object-type-delimiter': [2, 'comma'],
+    indent: [0],
+    'jest/no-focused-tests': [2],
+    'jest/no-identical-title': [2],
+    'jest/valid-expect': [2],
+    'max-len': [
+      2,
+      {
+        code: 80,
+        ignorePattern: maxLenIgnorePattern,
+        ignoreUrls: true,
+      },
+    ],
+    'no-const-assign': [2],
+    'no-extra-parens': [2, 'functions'],
+    'no-irregular-whitespace': [2],
+    'no-this-before-super': [2],
+    'no-var': [2],
+    'object-curly-spacing': [2, 'never'],
+    'object-shorthand': [2],
+    'prefer-arrow-callback': [2],
+    'prefer-const': [2],
+    quotes: [
+      2,
+      'single',
+      {
+        allowTemplateLiterals: true,
+        avoidEscape: true,
+      },
+    ],
+    semi: [2, 'always'],
+    'sort-keys': [2],
+    'space-before-blocks': [2],
+    'space-before-function-paren': [
+      2,
+      {anonymous: 'never', asyncArrow: 'always', named: 'never'},
+    ],
+    'space-in-parens': [2, 'never'],
+  }),
+});

--- a/packages/eslint-config-fb-strict/index.js
+++ b/packages/eslint-config-fb-strict/index.js
@@ -25,10 +25,9 @@ delete fbjsConfig.rules['babel/flow-object-type'];
 module.exports = Object.assign({}, fbjsConfig, {
   env: {
     es6: true,
-    'jest/globals': true,
     node: true,
   },
-  plugins: fbjsConfig.plugins.concat(['jest']),
+  plugins: fbjsConfig.plugins,
   rules: Object.assign({}, fbjsConfig.rules, {
     'array-bracket-spacing': [2, 'never'],
     'arrow-parens': [2, 'as-needed'],
@@ -47,9 +46,6 @@ module.exports = Object.assign({}, fbjsConfig, {
     'eol-last': [2],
     'flowtype/object-type-delimiter': [2, 'comma'],
     indent: [0],
-    'jest/no-focused-tests': [2],
-    'jest/no-identical-title': [2],
-    'jest/valid-expect': [2],
     'max-len': [
       2,
       {

--- a/packages/eslint-config-fb-strict/package.json
+++ b/packages/eslint-config-fb-strict/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "eslint-config-fb-strict",
+  "version": "26.0.0",
+  "description": "",
+  "repository": "facebook/fbjs",
+  "license": "MIT",
+  "main": "index.js",
+  "files": [
+    "index.js"
+  ],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "eslint-config-fbjs": "^3.1.1"
+  },
+  "peerDependencies": {
+    "babel-eslint": "^8.0.0 || ^9.0.0 || ^10.0.0",
+    "eslint": "^5.1.0 || ^6.0.0",
+    "eslint-plugin-babel": "^4.1.1 || ^5.2.1",
+    "eslint-plugin-flowtype": "^2.43.0 || ^3.0.0 || ^4.0.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-react": "^7.6.1"
+  }
+}


### PR DESCRIPTION
This currently lives in the Jest repo. I don't think there's a good reason for that, especially as that repo has moved away from Flow and `babel-eslint` towards a TS toolchain.

I plan to delete the source code from Jest's repo

https://github.com/facebook/jest/tree/92f74cd1fa057bc71890cd01018e6287fd24612b/packages/eslint-config-fb-strict