### PR TITLE
Fix require shadowing in `inline-requires` plugin

### DIFF
--- a/packages/babel-preset-fbjs/plugins/__tests__/__snapshots__/inline-requires-test.js.snap
+++ b/packages/babel-preset-fbjs/plugins/__tests__/__snapshots__/inline-requires-test.js.snap
@@ -10,6 +10,32 @@ var foo = require(\\"foo\\");
 "
 `;
 
+exports[`inline-requires does not transform require calls if its not needed: does not transform require calls if its not needed 1`] = `
+"
+function test () {
+  function require(condition) {
+    if (!condition) {
+      throw new Error('The condition is false');
+    }
+  }
+
+  require('test');
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+function test() {
+  function require(condition) {
+    if (!condition) {
+      throw new Error('The condition is false');
+    }
+  }
+
+  require('test');
+}
+"
+`;
+
 exports[`inline-requires ensures that the inlined require still points to the global require function even if local require is not called: ensures that the inlined require still points to the global require function even if local require is not called 1`] = `
 "
 const foo = require('foo');
@@ -34,6 +60,34 @@ function test() {
   }
 
   require('foo').isOnline();
+}
+"
+`;
+
+exports[`inline-requires ensures that the inlined require still points to the global require function with inlineableCalls options: ensures that the inlined require still points to the global require function with inlineableCalls options 1`] = `
+"
+const foo = customStuff('foo');
+
+function test() {
+  function customStuff(condition) {
+    if (!condition) {
+      throw new Error('Condition is falsy');
+    }
+  }
+
+  customStuff(foo.isOnline());
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+function test() {
+  function _customStuff(condition) {
+    if (!condition) {
+      throw new Error('Condition is falsy');
+    }
+  }
+
+  _customStuff(customStuff('foo').isOnline());
 }
 "
 `;

--- a/packages/babel-preset-fbjs/plugins/__tests__/__snapshots__/inline-requires-test.js.snap
+++ b/packages/babel-preset-fbjs/plugins/__tests__/__snapshots__/inline-requires-test.js.snap
@@ -10,7 +10,7 @@ var foo = require(\\"foo\\");
 "
 `;
 
-exports[`inline-requires does not transform require calls if its not needed: does not transform require calls if its not needed 1`] = `
+exports[`inline-requires does not transform require calls if it is not needed: does not transform require calls if it is not needed 1`] = `
 "
 function test () {
   function require(condition) {

--- a/packages/babel-preset-fbjs/plugins/__tests__/__snapshots__/inline-requires-test.js.snap
+++ b/packages/babel-preset-fbjs/plugins/__tests__/__snapshots__/inline-requires-test.js.snap
@@ -10,6 +10,62 @@ var foo = require(\\"foo\\");
 "
 `;
 
+exports[`inline-requires ensures that the inlined require still points to the global require function even if local require is not called: ensures that the inlined require still points to the global require function even if local require is not called 1`] = `
+"
+const foo = require('foo');
+
+function test() {
+  function require(condition) {
+    if (!condition) {
+      throw new Error('Condition is falsy');
+    }
+  }
+
+  foo.isOnline();
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+function test() {
+  function _require(condition) {
+    if (!condition) {
+      throw new Error('Condition is falsy');
+    }
+  }
+
+  require('foo').isOnline();
+}
+"
+`;
+
+exports[`inline-requires ensures that the inlined require still points to the global require function: ensures that the inlined require still points to the global require function 1`] = `
+"
+const foo = require('foo');
+
+function test() {
+  function require(condition) {
+    if (!condition) {
+      throw new Error('Condition is falsy');
+    }
+  }
+
+  require(foo.isOnline());
+}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+function test() {
+  function _require(condition) {
+    if (!condition) {
+      throw new Error('Condition is falsy');
+    }
+  }
+
+  _require(require('foo').isOnline());
+}
+"
+`;
+
 exports[`inline-requires ignores require properties (as identifiers) that are re-assigned: ignores require properties (as identifiers) that are re-assigned 1`] = `
 "
 var X = require(\\"X\\");

--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -67,7 +67,7 @@ pluginTester({
           require(foo.isOnline());
         }
         `,
-      snapshot: true
+      snapshot: true,
     },
 
     'ensures that the inlined require still points to the global require function with inlineableCalls options': {
@@ -84,7 +84,7 @@ pluginTester({
           customStuff(foo.isOnline());
         }
         `,
-      snapshot: true
+      snapshot: true,
     },
 
     'ensures that the inlined require still points to the global require function even if local require is not called': {
@@ -101,7 +101,7 @@ pluginTester({
           foo.isOnline();
         }
         `,
-      snapshot: true
+      snapshot: true,
     },
 
     'does not transform require calls if require is redeclared in the same declaration scope': {
@@ -116,7 +116,7 @@ pluginTester({
 
         console.log(foo.test);
       `,
-      snapshot: false
+      snapshot: false,
     },
 
     'does not transform require calls if require is redeclared in the global scope': {
@@ -132,7 +132,7 @@ pluginTester({
           console.log(foo.test);
         }
       `,
-      snapshot: false
+      snapshot: false,
     },
 
     'does not transform require calls if its not needed': {
@@ -147,7 +147,7 @@ pluginTester({
           require('test');
         }
       `,
-      snapshot: true
+      snapshot: true,
     },
 
     'inlines requires that are referenced before the require statement': {
@@ -245,7 +245,7 @@ describe('inline-requires', () => {
       ast: true,
       compact: true,
       plugins: [
-        [require('@babel/plugin-transform-modules-commonjs'), { strict: false }],
+        [require('@babel/plugin-transform-modules-commonjs'), {strict: false}],
         [inlineRequiresPlugin, options],
       ],
     });
@@ -256,7 +256,7 @@ describe('inline-requires', () => {
     );
   };
 
-  it('should be compatible with other transforms like transform-modules-commonjs', function () {
+  it('should be compatible with other transforms like transform-modules-commonjs', function() {
     compare(
       ['import Imported from "foo";', 'console.log(Imported);'],
       [
@@ -267,7 +267,7 @@ describe('inline-requires', () => {
     );
   });
 
-  it('should be compatible with `transform-modules-commonjs` when using named imports', function () {
+  it('should be compatible with `transform-modules-commonjs` when using named imports', function() {
     compare(
       [
         'import {a} from "./a";',
@@ -285,7 +285,7 @@ describe('inline-requires', () => {
     );
   });
 
-  it('should remove loc information from nodes', function () {
+  it('should remove loc information from nodes', function() {
     const ast = transform(['var x = require("x"); x']).ast;
     const expression = ast.program.body[0].expression;
 

--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -53,6 +53,56 @@ pluginTester({
       snapshot: false,
     },
 
+    'ensures that the inlined require still points to the global require function': {
+      code: `
+        const foo = require('foo');
+
+        function test() {
+          function require(condition) {
+            if (!condition) {
+              throw new Error('Condition is falsy');
+            }
+          }
+
+          require(foo.isOnline());
+        }
+        `,
+        snapshot: true
+    },
+
+    'ensures that the inlined require still points to the global require function even if local require is not called': {
+      code: `
+        const foo = require('foo');
+
+        function test() {
+          function require(condition) {
+            if (!condition) {
+              throw new Error('Condition is falsy');
+            }
+          }
+
+          foo.isOnline();
+        }
+        `,
+        snapshot: true
+    },
+
+
+    'does not transform require calls if require is redeclared in the global scope': {
+      code: `
+        function require(condition) {
+          if (!condition) {
+            throw new Error('Condition is falsy');
+          }
+        }
+
+        const foo = require('foo');
+
+        console.log(foo.test);
+      `,
+      snapshot: false
+    },
+
     'inlines requires that are referenced before the require statement': {
       code: [
         'function foo() {',

--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -136,7 +136,7 @@ pluginTester({
       snapshot: false,
     },
 
-    'does not transform require calls if its not needed': {
+    'does not transform require calls if it is not needed': {
       code: `
         function test () {
           function require(condition) {

--- a/packages/babel-preset-fbjs/plugins/inline-requires.js
+++ b/packages/babel-preset-fbjs/plugins/inline-requires.js
@@ -68,7 +68,7 @@ module.exports = babel => ({
               if (parseResult == null) {
                 return;
               }
-              const { declarationPath, moduleName } = parseResult;
+              const {declarationPath, moduleName} = parseResult;
 
               const init = declarationPath.node.init;
               const name = declarationPath.node.id
@@ -91,7 +91,9 @@ module.exports = babel => ({
               for (const referencePath of binding.referencePaths) {
                 excludeMemberAssignment(moduleName, referencePath, state);
                 try {
-                  const requireBinding = referencePath.scope.getBinding(requireName);
+                  const requireBinding = referencePath.scope.getBinding(
+                    requireName
+                  );
                   if (requireBinding != null) {
                     if (requireBinding.scope === declarationPath.scope) {
                       thrown = true;
@@ -116,7 +118,7 @@ module.exports = babel => ({
             ignoredRequires,
             inlineableCalls,
             membersAssigned: new Map(),
-          },
+          }
         );
       },
     },
@@ -184,9 +186,9 @@ function parseInlineableAlias(path, state) {
   return !isValid || path.parentPath.node == null
     ? null
     : {
-      declarationPath: path.parentPath,
-      moduleName,
-    };
+        declarationPath: path.parentPath,
+        moduleName,
+      };
 }
 
 function parseInlineableMemberAlias(path, state) {
@@ -207,9 +209,9 @@ function parseInlineableMemberAlias(path, state) {
     isExcludedMemberAssignment(moduleName, memberPropertyName, state)
     ? null
     : {
-      declarationPath: path.parentPath.parentPath,
-      moduleName,
-    };
+        declarationPath: path.parentPath.parentPath,
+        moduleName,
+      };
 }
 
 function getInlineableModule(node, state) {
@@ -233,13 +235,13 @@ function getInlineableModule(node, state) {
   if (moduleName == null) {
     moduleName =
       node['arguments'][0].type === 'CallExpression' &&
-        node['arguments'][0].callee.type === 'MemberExpression' &&
-        node['arguments'][0].callee.object.type === 'Identifier' &&
-        state.inlineableCalls.has(node['arguments'][0].callee.object.name) &&
-        node['arguments'][0].callee.property.type === 'Identifier' &&
-        node['arguments'][0].callee.property.name === 'resolve' &&
-        node['arguments'][0]['arguments'].length >= 1 &&
-        node['arguments'][0]['arguments'][0].type === 'StringLiteral'
+      node['arguments'][0].callee.type === 'MemberExpression' &&
+      node['arguments'][0].callee.object.type === 'Identifier' &&
+      state.inlineableCalls.has(node['arguments'][0].callee.object.name) &&
+      node['arguments'][0].callee.property.type === 'Identifier' &&
+      node['arguments'][0].callee.property.name === 'resolve' &&
+      node['arguments'][0]['arguments'].length >= 1 &&
+      node['arguments'][0]['arguments'][0].type === 'StringLiteral'
         ? node['arguments'][0]['arguments'][0].value
         : null;
   }

--- a/packages/babel-preset-fbjs/plugins/inline-requires.js
+++ b/packages/babel-preset-fbjs/plugins/inline-requires.js
@@ -39,15 +39,6 @@
 module.exports = babel => ({
   name: 'inline-requires',
   visitor: {
-    CallExpression(path, state) {
-      const node = path.node;
-      // Rename an existing require function to make sure any inserted `require` calls point to the
-      // global CommonJS require function.
-      const requireBinding = path.scope.getBinding('require');
-      if (requireBinding != null && requireBinding.scope.parent != null) {
-        path.scope.rename('require');
-      }
-    },
     Program: {
       exit(path, state) {
         const ignoredRequires = new Set();
@@ -77,14 +68,8 @@ module.exports = babel => ({
               if (parseResult == null) {
                 return;
               }
+              const { declarationPath, moduleName } = parseResult;
 
-              // Do not transform require calls if require is redeclared in global scope
-              const requireBinding = path.scope.getBinding('require');
-              if (requireBinding != null && requireBinding.scope.parent == null) {
-                return;
-              }
-
-              const {declarationPath, moduleName} = parseResult;
               const init = declarationPath.node.init;
               const name = declarationPath.node.id
                 ? declarationPath.node.id.name
@@ -101,10 +86,19 @@ module.exports = babel => ({
                 enter: path => deleteLocation(path.node),
               });
 
+              const requireName = path.node.callee.name;
               let thrown = false;
               for (const referencePath of binding.referencePaths) {
                 excludeMemberAssignment(moduleName, referencePath, state);
                 try {
+                  const requireBinding = referencePath.scope.getBinding(requireName);
+                  if (requireBinding != null) {
+                    if (requireBinding.scope === declarationPath.scope) {
+                      thrown = true;
+                      continue;
+                    }
+                    requireBinding.scope.rename(requireName);
+                  }
                   referencePath.replaceWith(init);
                 } catch (error) {
                   thrown = true;
@@ -190,9 +184,9 @@ function parseInlineableAlias(path, state) {
   return !isValid || path.parentPath.node == null
     ? null
     : {
-        declarationPath: path.parentPath,
-        moduleName,
-      };
+      declarationPath: path.parentPath,
+      moduleName,
+    };
 }
 
 function parseInlineableMemberAlias(path, state) {
@@ -213,9 +207,9 @@ function parseInlineableMemberAlias(path, state) {
     isExcludedMemberAssignment(moduleName, memberPropertyName, state)
     ? null
     : {
-        declarationPath: path.parentPath.parentPath,
-        moduleName,
-      };
+      declarationPath: path.parentPath.parentPath,
+      moduleName,
+    };
 }
 
 function getInlineableModule(node, state) {
@@ -239,13 +233,13 @@ function getInlineableModule(node, state) {
   if (moduleName == null) {
     moduleName =
       node['arguments'][0].type === 'CallExpression' &&
-      node['arguments'][0].callee.type === 'MemberExpression' &&
-      node['arguments'][0].callee.object.type === 'Identifier' &&
-      state.inlineableCalls.has(node['arguments'][0].callee.object.name) &&
-      node['arguments'][0].callee.property.type === 'Identifier' &&
-      node['arguments'][0].callee.property.name === 'resolve' &&
-      node['arguments'][0]['arguments'].length >= 1 &&
-      node['arguments'][0]['arguments'][0].type === 'StringLiteral'
+        node['arguments'][0].callee.type === 'MemberExpression' &&
+        node['arguments'][0].callee.object.type === 'Identifier' &&
+        state.inlineableCalls.has(node['arguments'][0].callee.object.name) &&
+        node['arguments'][0].callee.property.type === 'Identifier' &&
+        node['arguments'][0].callee.property.name === 'resolve' &&
+        node['arguments'][0]['arguments'].length >= 1 &&
+        node['arguments'][0]['arguments'][0].type === 'StringLiteral'
         ? node['arguments'][0]['arguments'][0].value
         : null;
   }

--- a/packages/babel-preset-fbjs/plugins/inline-requires.js
+++ b/packages/babel-preset-fbjs/plugins/inline-requires.js
@@ -97,12 +97,7 @@ module.exports = babel => ({
               for (const referencePath of binding.referencePaths) {
                 excludeMemberAssignment(moduleName, referencePath, state);
                 try {
-                  const requireBinding = referencePath.scope.getBinding(
-                    requireName
-                  );
-                  if (requireBinding != null) {
-                    requireBinding.scope.rename(requireName);
-                  }
+                  referencePath.scope.rename(requireName);
                   referencePath.replaceWith(init);
                 } catch (error) {
                   thrown = true;
@@ -120,7 +115,7 @@ module.exports = babel => ({
             ignoredRequires,
             inlineableCalls,
             membersAssigned: new Map(),
-          }
+          },
         );
       },
     },

--- a/packages/babel-preset-fbjs/plugins/inline-requires.js
+++ b/packages/babel-preset-fbjs/plugins/inline-requires.js
@@ -186,9 +186,9 @@ function parseInlineableAlias(path, state) {
   return !isValid || path.parentPath.node == null
     ? null
     : {
-        declarationPath: path.parentPath,
-        moduleName,
-      };
+      declarationPath: path.parentPath,
+      moduleName,
+    };
 }
 
 function parseInlineableMemberAlias(path, state) {
@@ -209,9 +209,9 @@ function parseInlineableMemberAlias(path, state) {
     isExcludedMemberAssignment(moduleName, memberPropertyName, state)
     ? null
     : {
-        declarationPath: path.parentPath.parentPath,
-        moduleName,
-      };
+      declarationPath: path.parentPath.parentPath,
+      moduleName,
+    };
 }
 
 function getInlineableModule(node, state) {

--- a/packages/babel-preset-fbjs/plugins/inline-requires.js
+++ b/packages/babel-preset-fbjs/plugins/inline-requires.js
@@ -250,16 +250,8 @@ function getInlineableModule(path, state) {
   }
 
   // Check if require is in any parent scope
-  let parentPath = path.parentPath;
-  let isRequireInScope = false;
   const fnName = node.callee.name;
-  while (parentPath) {
-    if (parentPath.scope.getBinding(fnName) != null) {
-      isRequireInScope = true;
-      break;
-    }
-    parentPath = parentPath.parentPath;
-  }
+  const isRequireInScope = path.scope.getBinding(fnName) != null;
 
   return moduleName == null ||
     state.ignoredRequires.has(moduleName) ||


### PR DESCRIPTION
1. It's possible that the require is overridden in a module (or scope) and no longer points to the CommonJS require function. The plugin doesn't respect this. For this, we will now honor the require redeclaration if in global scope.
2. If the require function is re-declared in a sub-scope, e.g. a function. The plugin changes the semantics of the program by inlining the require call without renaming the scoped require declaration (it then accidentally calls the custom require implementation). This is fixed by renaming local scope "require" functions and calls to "_require" 