### PR TITLE
Eliminate usage of @flow weak in keyMirrorRecursive

### DIFF
--- a/packages/fbjs/src/key-mirror/keyMirrorRecursive.js
+++ b/packages/fbjs/src/key-mirror/keyMirrorRecursive.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @providesModule keyMirrorRecursive
- * @flow weak
+ * @flow
  * @typechecks
  */
 
@@ -29,7 +29,8 @@ var invariant = require('invariant');
  *   var CONSTANTS = keyMirror({FOO: {BAR: null}}, 'NameSpace');
  *   console.log(CONSTANTS.FOO.BAR); // NameSpace.FOO.BAR
  */
-function keyMirrorRecursive<T>(obj: T, prefix?: ?string): T {
+function keyMirrorRecursive<T: {...}>(obj: T, prefix?: ?string): T {
+  // $FlowFixMe
   return keyMirrorRecursiveInternal(obj, prefix);
 }
 

--- a/packages/fbjs/src/key-mirror/keyMirrorRecursive.js
+++ b/packages/fbjs/src/key-mirror/keyMirrorRecursive.js
@@ -29,7 +29,7 @@ var invariant = require('invariant');
  *   var CONSTANTS = keyMirror({FOO: {BAR: null}}, 'NameSpace');
  *   console.log(CONSTANTS.FOO.BAR); // NameSpace.FOO.BAR
  */
-function keyMirrorRecursive<T: {...}>(obj: T, prefix?: ?string): T {
+function keyMirrorRecursive<T: {}>(obj: T, prefix?: ?string): T {
   // $FlowFixMe
   return keyMirrorRecursiveInternal(obj, prefix);
 }


### PR DESCRIPTION
`@flow weak` is deprecated. Replace single instance with `@flow` instead and add suppression on error which was previously hidden. 