### PR TITLE
fix: this.each is not a function for prototype.js

### DIFF
--- a/packages/fbjs/src/__forks__/cx.js
+++ b/packages/fbjs/src/__forks__/cx.js
@@ -29,7 +29,7 @@ function cx(classNames) {
       .map(replace)
       .join(' ');
   }
-  return Array.prototype.map.call(arguments, replace).join(' ');
+  return Array.prototype.map.call(Array.from(arguments), replace).join(' ');
 }
 
 function replace(str) {


### PR DESCRIPTION
There is a TypeError: this.each is not a function if we use prototype.js
//cdnjs.cloudflare.com/ajax/libs/prototype/1.7.0.0/prototype.js

![Screenshot from 2021-04-15 21-15-17](https://user-images.githubusercontent.com/856090/114974873-dcb90100-9ea0-11eb-9e65-fc072fe6a000.png)

A similar issue has happened in quilljs - https://github.com/quilljs/quill/issues/1261

We have some react web app running over client websites. Here client is using protoype.js, causing conflict with **fbjs/lib/cx.js**.

To fix this, we manually update cx.js from
```js
Array.prototype.map.call(arguments, replace).join(' ');
```
to
```js
Array.prototype.map.call(Array.from(arguments), replace).join(' ');
```
It fixed our issue.