### PR TITLE
[babel-preset-fbjs] Avoid generating duplicate references to the same node

### DIFF
--- a/packages/babel-preset-fbjs/plugins/__tests__/dev-declaration-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/dev-declaration-test.js
@@ -11,11 +11,14 @@
 
 let babel = require('@babel/core');
 let devDeclaration = require('../dev-declaration');
+const validateOutputAst = require('../test-utils/validateOutputAst');
 
 function transform(input) {
-  return babel.transform(input, {
+  const result = babel.transform(input, {
     plugins: ['@babel/plugin-syntax-flow', devDeclaration],
-  }).code;
+  });
+  validateOutputAst(result.ast);
+  return result.code;
 }
 
 function compare(input, output) {

--- a/packages/babel-preset-fbjs/plugins/__tests__/dev-expression-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/dev-expression-test.js
@@ -11,11 +11,14 @@
 
 let babel = require('@babel/core');
 let devExpression = require('../dev-expression');
+const validateOutputAst = require('../test-utils/validateOutputAst');
 
 function transform(input) {
-  return babel.transform(input, {
+  const result = babel.transform(input, {
     plugins: [devExpression],
-  }).code;
+  });
+  validateOutputAst(result.ast);
+  return result.code;
 }
 
 function compare(input, output) {

--- a/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/inline-requires-test.js
@@ -13,6 +13,7 @@
 const babel = require('@babel/core');
 const inlineRequiresPlugin = require('../inline-requires');
 const pluginTester = require('babel-plugin-tester');
+const validateOutputAst = require('../test-utils/validateOutputAst');
 
 pluginTester({
   plugin: inlineRequiresPlugin,
@@ -299,4 +300,9 @@ describe('inline-requires', () => {
     expectNoLocation(expression);
     expectNoLocation(expression.arguments[0]);
   });
+
+  it('should not emit duplicate nodes', function () {
+    const ast = transform(['var foo = require("foo");', 'foo.bar()', 'foo.baz()']).ast;
+    validateOutputAst(ast);
+  })
 });

--- a/packages/babel-preset-fbjs/plugins/__tests__/object-assign-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/object-assign-test.js
@@ -11,11 +11,14 @@
 
 let babel = require('@babel/core');
 let assign = require('../object-assign');
+const validateOutputAst = require('../test-utils/validateOutputAst');
 
 function transform(input) {
-  return babel.transform(input, {
+  const result = babel.transform(input, {
     plugins: [assign],
-  }).code;
+  });
+  validateOutputAst(result.ast);
+  return result.code;
 }
 
 function compare(input, output) {

--- a/packages/babel-preset-fbjs/plugins/__tests__/rewrite-modules-test.js
+++ b/packages/babel-preset-fbjs/plugins/__tests__/rewrite-modules-test.js
@@ -13,6 +13,7 @@ jest.dontMock('../rewrite-modules');
 describe('rewrite-modules', function() {
   let babel = require('@babel/core');
   let rewriteModules = require('../rewrite-modules');
+  const validateOutputAst = require('../test-utils/validateOutputAst');
 
   function normalizeResults(code) {
     return code && code.replace(/\s/g, '');
@@ -27,7 +28,8 @@ describe('rewrite-modules', function() {
             plugins: [[rewriteModules, {map: {'test': 'test/test'}}]],
           }
         );
-
+        
+        validateOutputAst(result.ast);
         expect(result.code).toEqual('require("test/test");');
       });
 
@@ -42,6 +44,7 @@ describe('rewrite-modules', function() {
           }
         );
 
+        validateOutputAst(result.ast);
         expect(result.code).toEqual('import type Test from "test/test";');
       });
 
@@ -58,6 +61,7 @@ describe('rewrite-modules', function() {
           }
         );
 
+        validateOutputAst(result.ast);
         expect(result.code).toEqual(expected);
       });
 
@@ -105,6 +109,7 @@ describe('rewrite-modules', function() {
           }
         );
 
+        validateOutputAst(result.ast);
         expect(normalizeResults(result.code))
           .toEqual(normalizeResults(expected));
       });

--- a/packages/babel-preset-fbjs/plugins/inline-requires.js
+++ b/packages/babel-preset-fbjs/plugins/inline-requires.js
@@ -41,6 +41,7 @@ module.exports = babel => ({
   visitor: {
     Program: {
       exit(path, state) {
+        const t = babel.types;
         const ignoredRequires = new Set();
         const inlineableCalls = new Set(['require']);
 
@@ -95,7 +96,7 @@ module.exports = babel => ({
                 excludeMemberAssignment(moduleName, referencePath, state);
                 try {
                   referencePath.scope.rename(requireFnName);
-                  referencePath.replaceWith(init);
+                  referencePath.replaceWith(t.cloneDeep(init));
                 } catch (error) {
                   thrown = true;
                 }

--- a/packages/babel-preset-fbjs/plugins/test-utils/validateOutputAst.js
+++ b/packages/babel-preset-fbjs/plugins/test-utils/validateOutputAst.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const t = require('@babel/types');
+
+module.exports = function validateOutputAst(ast) {
+  const seenNodes = new Set();
+  t.traverseFast(ast, function enter(node) {
+    if (seenNodes.has(node)) {
+      throw new Error('Found a duplicate node in the output, which can cause'
+        + ' undefined behavior in Babel.');
+    }
+    seenNodes.add(node);
+  })
+}


### PR DESCRIPTION
Babel does not deal well with multiple references to the same node in a single AST. Specifically it can lead to `NodePath`s not being unique and therefore to incorrect scope analyses - see https://github.com/babel/babel/issues/6375 for pointers to manifestations of this in Babel.

These days, Babel's test suite ensures that Babel's first-party plugins do not emit such duplicates (https://github.com/babel/babel/pull/7149) but there is no such guarantee for third-party plugins.

This PR:

1. fixes the logic in `inline-requires` to avoid emitting repeated nodes.
2. adds tests to *all* the Babel plugins in this repo asserting that there are no repeated nodes in the resulting ASTs.