### PR TITLE
[fbjs] Update prepublish script to prepare

### DIFF
--- a/packages/fbjs/package.json
+++ b/packages/fbjs/package.json
@@ -8,7 +8,7 @@
     "build": "gulp build",
     "postbuild": "node node_modules/fbjs-scripts/node/check-lib-requires.js lib",
     "lint": "eslint .",
-    "prepublish": "yarn run build",
+    "prepare": "yarn run build",
     "pretest": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
     "test": "NODE_ENV=test jest",
     "test-babel-presets": "cd babel-preset && yarn install && yarn test",


### PR DESCRIPTION
Prepublish has been deprecated for a while and this footgun resulted in a 3.0.3 being published without being built.