### PR TITLE
Update ua-parser-js dependency from v0.7.30 to v0.7.35

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 packages/fbjs/lib/*
 packages/fbjs/module-map.json
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
-# FBJS
+# Patched FBJS
 
+This is a patched version of the Facebook/Meta's JS utilities. This version includes an upgrade ua-parser-js version 0.7.35 to fix [CVE-2022-25927](https://www.tenable.com/cve/CVE-2022-25927)
+
+The original readme is below:
+
+---
 ## Purpose
 
 To make it easier for Facebook to share and consume our own JavaScript. Primarily this will allow us to ship code without worrying too much about where it lives, keeping with the spirit of `@providesModule` but working in the broader JavaScript ecosystem.
 
-For more information on how to build and use FBJS, click [here](https://github.com/facebook/fbjs/tree/main/packages/fbjs). This library includes a number of packages that can be accessed in the [packages](https://github.com/facebook/fbjs/tree/main/packages) folder. For more information on what each package does and how to run it, access the individual package from within the folder. 
+For more information on how to build and use FBJS, click [here](https://github.com/facebook/fbjs/tree/main/packages/fbjs). This library includes a number of packages that can be accessed in the [packages](https://github.com/facebook/fbjs/tree/main/packages) folder. For more information on what each package does and how to run it, access the individual package from within the folder.
 
 **Note:** If you are consuming the code here and you are not also a Facebook project, be prepared for a bad time. APIs may appear or disappear and we may not follow semver strictly, though we will do our best to. This library is being published with our use cases in mind and is not necessarily meant to be consumed by the broader public. In order for us to move fast and ship projects like React and Relay, we've made the decision to not support everybody. We probably won't take your feature requests unless they align with our needs. There will be overlap in functionality here and in other open source projects.
 

--- a/packages/fbjs/CHANGELOG.md
+++ b/packages/fbjs/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.0.5]
+
+### Fixed
+- Upgraded ua-parser-js dependency from v0.7.30 to v0.7.35 to fix [CVE-2022-25927](https://www.tenable.com/cve/CVE-2022-25927)
+
 ## [3.0.4]
 
 ### Fixed

--- a/packages/fbjs/package.json
+++ b/packages/fbjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fbjs",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "A collection of utility libraries used by other Facebook JS projects",
   "main": "index.js",
   "repository": "facebook/fbjs",

--- a/packages/fbjs/yarn.lock
+++ b/packages/fbjs/yarn.lock
@@ -5277,9 +5277,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 ua-parser-js@^0.7.30:
-  version "0.7.30"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.30.tgz#4cf5170e8b55ac553fe8b38df3a82f0669671f0b"
-  integrity sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg==
+  version "0.7.35"
+  resolved "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/ua-parser-js/-/ua-parser-js-0.7.35.tgz#8bda4827be4f0b1dda91699a29499575a1f1d307"
+  integrity sha1-i9pIJ75PCx3akWmaKUmVdaHx0wc=
 
 uglify-js@^3.1.4:
   version "3.13.5"


### PR DESCRIPTION
This is a patched version of the Facebook/Meta's JS utilities. This version includes an upgrade ua-parser-js version 0.7.35 to fix [CVE-2022-25927](https://www.tenable.com/cve/CVE-2022-25927)