### PR TITLE
bump ua-parser-js from 0.7.30 to 1.0.35

### DIFF
--- a/packages/fbjs/package.json
+++ b/packages/fbjs/package.json
@@ -69,7 +69,7 @@
     "object-assign": "^4.1.0",
     "promise": "^7.1.1",
     "setimmediate": "^1.0.5",
-    "ua-parser-js": "^0.7.30"
+    "ua-parser-js": "^1.0.35"
   },
   "devEngines": {
     "node": ">=4.x",

--- a/packages/fbjs/yarn.lock
+++ b/packages/fbjs/yarn.lock
@@ -5276,10 +5276,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-ua-parser-js@^0.7.30:
-  version "0.7.30"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.30.tgz#4cf5170e8b55ac553fe8b38df3a82f0669671f0b"
-  integrity sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg==
+ua-parser-js@^1.0.35:
+  version "1.0.35"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.35.tgz#c4ef44343bc3db0a3cbefdf21822f1b1fc1ab011"
+  integrity sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==
 
 uglify-js@^3.1.4:
   version "3.13.5"


### PR DESCRIPTION
## Overview
This PR bumps `ua-parser-js` from 0.7.30 to 1.0.35, which contains, among a few fixes, a resolution for the [Regular Expression Denial of Service (ReDoS)](https://security.snyk.io/vuln/SNYK-JS-UAPARSERJS-3244450) vulnerability.