### PR TITLE
upgrade promise lib to 8.3.0

### DIFF
--- a/packages/fbjs/package.json
+++ b/packages/fbjs/package.json
@@ -67,7 +67,7 @@
     "fbjs-css-vars": "^1.0.0",
     "loose-envify": "^1.0.0",
     "object-assign": "^4.1.0",
-    "promise": "^7.1.1",
+    "promise": "^8.3.0",
     "setimmediate": "^1.0.5",
     "ua-parser-js": "^1.0.35"
   },


### PR DESCRIPTION
Motivation:
Allows usage `Promise.allSettled` added in [8.2.0](https://github.com/then/promise/pull/171)
Also reduces dependency tree size for most users and allow usage of `Promise.