### PR TITLE
Add homepage and bugs.url package metadata

### DIFF
--- a/packages/babel-preset-fbjs/package.json
+++ b/packages/babel-preset-fbjs/package.json
@@ -3,6 +3,10 @@
   "version": "3.4.0",
   "description": "Babel preset for Facebook projects.",
   "repository": "facebook/fbjs",
+  "homepage": "https://github.com/facebook/fbjs/tree/main/packages/babel-preset-fbjs#readme",
+  "bugs": {
+    "url": "https://github.com/facebook/fbjs/issues"
+  },
   "license": "MIT",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- adds missing npm support/discovery metadata for `babel-preset-fbjs`
- updates only `packages/babel-preset-fbjs/package.json`

## Metadata added
- `homepage`: `https://github.com/facebook/fbjs/tree/main/packages/babel-preset-fbjs#readme`
- `bugs.url`: `https://github.com/facebook/fbjs/issues`

## Validation
- parsed `packages/babel-preset-fbjs/package.json` as JSON after the change
- confirmed the manifest still has `name: babel-preset-fbjs`
- checked this is metadata-only: no runtime code, dependencies, exports, generated assets, or build behavior changed

This small metadata fix makes the published npm package expose the project support/discovery information once the package is next released.